### PR TITLE
[#12] 약 추가 바텀 시트 구현

### DIFF
--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -39,6 +39,10 @@
 		BDFE75D6278782AA00014BE1 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = BDFE75D5278782AA00014BE1 /* FirebaseAnalytics */; };
 		BDFE75D8278782AA00014BE1 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = BDFE75D7278782AA00014BE1 /* FirebaseCrashlytics */; };
 		BDFE75DE278786AE00014BE1 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = BDFE75DD278786AE00014BE1 /* Then */; };
+		EC03760E278B2E4000CA4B54 /* AddMedicineSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC03760C278B2E4000CA4B54 /* AddMedicineSheet.swift */; };
+		EC03760F278B2E4000CA4B54 /* AddMedicineSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = EC03760D278B2E4000CA4B54 /* AddMedicineSheet.xib */; };
+		EC037612278B2EAF00CA4B54 /* AddMedicineTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC037610278B2EAF00CA4B54 /* AddMedicineTableViewCell.swift */; };
+		EC037613278B2EAF00CA4B54 /* AddMedicineTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = EC037611278B2EAF00CA4B54 /* AddMedicineTableViewCell.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -67,6 +71,10 @@
 		BDDAA5A62789BCD3000C0AF8 /* URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
 		BDDAA5A72789BCD3000C0AF8 /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		BDDAA5A82789BCD3000C0AF8 /* Text.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Text.swift; sourceTree = "<group>"; };
+		EC03760C278B2E4000CA4B54 /* AddMedicineSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMedicineSheet.swift; sourceTree = "<group>"; };
+		EC03760D278B2E4000CA4B54 /* AddMedicineSheet.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddMedicineSheet.xib; sourceTree = "<group>"; };
+		EC037610278B2EAF00CA4B54 /* AddMedicineTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMedicineTableViewCell.swift; sourceTree = "<group>"; };
+		EC037611278B2EAF00CA4B54 /* AddMedicineTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddMedicineTableViewCell.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -348,6 +356,7 @@
 		BD515E6A27877773003BD5A4 /* Medicine */ = {
 			isa = PBXGroup;
 			children = (
+				EC037614278B372500CA4B54 /* AddMedicineSheet */,
 			);
 			path = Medicine;
 			sourceTree = "<group>";
@@ -374,6 +383,17 @@
 				BDDAA5942789B2A2000C0AF8 /* generate.py */,
 			);
 			path = Script;
+			sourceTree = "<group>";
+		};
+		EC037614278B372500CA4B54 /* AddMedicineSheet */ = {
+			isa = PBXGroup;
+			children = (
+				EC03760C278B2E4000CA4B54 /* AddMedicineSheet.swift */,
+				EC03760D278B2E4000CA4B54 /* AddMedicineSheet.xib */,
+				EC037610278B2EAF00CA4B54 /* AddMedicineTableViewCell.swift */,
+				EC037611278B2EAF00CA4B54 /* AddMedicineTableViewCell.xib */,
+			);
+			path = AddMedicineSheet;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -462,9 +482,11 @@
 				BD64F8F02788B488009249D0 /* Pretendard-Bold.otf in Resources */,
 				BD64F8F22788B488009249D0 /* Pretendard-SemiBold.otf in Resources */,
 				BD515E45278770C7003BD5A4 /* LaunchScreen.storyboard in Resources */,
+				EC03760F278B2E4000CA4B54 /* AddMedicineSheet.xib in Resources */,
 				BDDAA5952789B2A2000C0AF8 /* generate.py in Resources */,
 				BD515E42278770C7003BD5A4 /* Assets.xcassets in Resources */,
 				BD64F8F32788B488009249D0 /* Pretendard-Regular.otf in Resources */,
+				EC037613278B2EAF00CA4B54 /* AddMedicineTableViewCell.xib in Resources */,
 				BDDAA581278997E1000C0AF8 /* Color.xcassets in Resources */,
 				BDDAA58327899C25000C0AF8 /* Image.xcassets in Resources */,
 				BD515E73278778F9003BD5A4 /* SampleViewController.xib in Resources */,
@@ -519,6 +541,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				BD515E6F2787784D003BD5A4 /* BaseViewController.swift in Sources */,
+				EC03760E278B2E4000CA4B54 /* AddMedicineSheet.swift in Sources */,
+				EC037612278B2EAF00CA4B54 /* AddMedicineTableViewCell.swift in Sources */,
 				BDDAA5AB2789BCD3000C0AF8 /* Image.swift in Sources */,
 				BDDAA5AC2789BCD3000C0AF8 /* URL.swift in Sources */,
 				BDDAA5AD2789BCD3000C0AF8 /* Color.swift in Sources */,

--- a/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineSheet.swift
+++ b/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineSheet.swift
@@ -13,9 +13,9 @@ final class AddMedicineSheet: UIViewController {
 
     // MARK: Properties
     
-    private let medicineTuple = [
-    (image: Image.icMyFillPlus, text: "내 약 추가"),
-    (image: Image.icFillSend, text: "다른 사람에게 약 전송")
+    private let targetListForMedicine = [
+        (image: Image.icMyFillPlus, text: "내 약 추가"),
+        (image: Image.icFillSend, text: "다른 사람에게 약 전송")
     ]
  
     // MARK: @IBOutlet Properties
@@ -47,7 +47,7 @@ extension AddMedicineSheet: UITableViewDelegate {
 
 extension AddMedicineSheet: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return medicineTuple.count
+        return targetListForMedicine.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -55,8 +55,8 @@ extension AddMedicineSheet: UITableViewDataSource {
         // 셀이 선택 되었을 때 배경색 변하지 않게
         medicineCell.selectionStyle = .none
         
-        medicineCell.medicineImageView.image = medicineTuple[indexPath.row].image
-        medicineCell.medicineTextLabel.text = medicineTuple[indexPath.row].text
+        medicineCell.medicineImageView.image = targetListForMedicine[indexPath.row].image
+        medicineCell.medicineTextLabel.text = targetListForMedicine[indexPath.row].text
         return medicineCell
     }
     

--- a/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineSheet.swift
+++ b/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineSheet.swift
@@ -1,0 +1,68 @@
+//
+//  AddMedicineSheet.swift
+//  SobokSobok
+//
+//  Created by 김승찬 on 2022/01/09.
+//
+
+import UIKit
+import EasyKit
+
+class AddMedicineSheet: UIViewController {
+
+    // MARK: Properties
+    
+    let medicineImage = [Image.icMyFillPlus, Image.icFillSend]
+    let medicineText = ["내 약 추가", "다른 사람에게 약 전송"]
+ 
+    // MARK: @IBOutlet Properties
+    
+    @IBOutlet var medicineTableView: UITableView!
+    
+    // MARK: - View Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        assignDelegation()
+    }
+    
+    // MARK: - Functions
+    
+    func assignDelegation() {
+        medicineTableView.dataSource = self
+        medicineTableView.delegate = self
+        medicineTableView.register(AddMedicineTableViewCell.self)
+    }
+}
+
+// MARK: - UITableViewDelegate
+extension AddMedicineSheet: UITableViewDelegate {
+    
+}
+
+// MARK: - UITableViewDataSource
+
+extension AddMedicineSheet: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return medicineImage.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let medicineCell = medicineTableView.dequeueReusableCell(for: indexPath, cellType: AddMedicineTableViewCell.self)
+        // 셀이 선택 되었을 때 배경색 변하지 않게
+        medicineCell.selectionStyle = .none
+        
+        medicineCell.medicineImageView.image = medicineImage[indexPath.row]
+        medicineCell.addMedicineLabel.text = medicineText[indexPath.row]
+        
+        return medicineCell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // 추후에 나머지 뷰 만들면 연결 예정
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 82
+    }
+}

--- a/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineSheet.swift
+++ b/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineSheet.swift
@@ -6,14 +6,17 @@
 //
 
 import UIKit
+
 import EasyKit
 
-class AddMedicineSheet: UIViewController {
+final class AddMedicineSheet: UIViewController {
 
     // MARK: Properties
     
-    let medicineImage = [Image.icMyFillPlus, Image.icFillSend]
-    let medicineText = ["내 약 추가", "다른 사람에게 약 전송"]
+    private let medicineTuple = [
+    (image: Image.icMyFillPlus, text: "내 약 추가"),
+    (image: Image.icFillSend, text: "다른 사람에게 약 전송")
+    ]
  
     // MARK: @IBOutlet Properties
     
@@ -44,7 +47,7 @@ extension AddMedicineSheet: UITableViewDelegate {
 
 extension AddMedicineSheet: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return medicineImage.count
+        return medicineTuple.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -52,9 +55,8 @@ extension AddMedicineSheet: UITableViewDataSource {
         // 셀이 선택 되었을 때 배경색 변하지 않게
         medicineCell.selectionStyle = .none
         
-        medicineCell.medicineImageView.image = medicineImage[indexPath.row]
-        medicineCell.addMedicineLabel.text = medicineText[indexPath.row]
-        
+        medicineCell.medicineImageView.image = medicineTuple[indexPath.row].image
+        medicineCell.medicineTextLabel.text = medicineTuple[indexPath.row].text
         return medicineCell
     }
     

--- a/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineSheet.xib
+++ b/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineSheet.xib
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AddMedicineSheet" customModule="SobokSobok" customModuleProvider="target">
+            <connections>
+                <outlet property="medicineTableView" destination="qcf-wB-G4R" id="bRT-5g-U3e"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fYK-Z4-dvC">
+                    <rect key="frame" x="0.0" y="698" width="414" height="164"/>
+                    <subviews>
+                        <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" style="plain" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="qcf-wB-G4R">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="164"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <color key="separatorColor" name="gray400_sub"/>
+                            <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                        </tableView>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstItem="qcf-wB-G4R" firstAttribute="top" secondItem="fYK-Z4-dvC" secondAttribute="top" id="7Yg-Ub-lA0"/>
+                        <constraint firstItem="qcf-wB-G4R" firstAttribute="leading" secondItem="fYK-Z4-dvC" secondAttribute="leading" id="dTE-hc-Phk"/>
+                        <constraint firstAttribute="bottom" secondItem="qcf-wB-G4R" secondAttribute="bottom" id="nKb-bM-8Bw"/>
+                        <constraint firstAttribute="trailing" secondItem="qcf-wB-G4R" secondAttribute="trailing" id="qQE-TE-amP"/>
+                        <constraint firstAttribute="height" constant="164" id="zgZ-gH-Iug"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" red="0.12156862745098039" green="0.12549019607843137" blue="0.13333333333333333" alpha="0.1314435422960725" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="fYK-Z4-dvC" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="94G-xo-9go"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="fYK-Z4-dvC" secondAttribute="trailing" id="emB-rV-HU2"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="fYK-Z4-dvC" secondAttribute="bottom" id="hj3-jP-fu9"/>
+            </constraints>
+            <point key="canvasLocation" x="132" y="132"/>
+        </view>
+    </objects>
+    <resources>
+        <namedColor name="gray400_sub">
+            <color red="0.76078431372549016" green="0.78823529411764703" blue="0.80784313725490198" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineTableViewCell.swift
+++ b/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineTableViewCell.swift
@@ -1,0 +1,26 @@
+//
+//  AddMedicineTableViewCell.swift
+//  SobokSobok
+//
+//  Created by 김승찬 on 2022/01/09.
+//
+
+import UIKit
+
+class AddMedicineTableViewCell: UITableViewCell {
+
+    @IBOutlet var medicineImageView: UIImageView!
+    @IBOutlet var addMedicineLabel: UILabel!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+     
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+   
+    }
+    
+}

--- a/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineTableViewCell.swift
+++ b/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineTableViewCell.swift
@@ -7,20 +7,9 @@
 
 import UIKit
 
-class AddMedicineTableViewCell: UITableViewCell {
+final class AddMedicineTableViewCell: UITableViewCell {
 
     @IBOutlet var medicineImageView: UIImageView!
-    @IBOutlet var addMedicineLabel: UILabel!
-    
-    override func awakeFromNib() {
-        super.awakeFromNib()
-     
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-   
-    }
+    @IBOutlet var medicineTextLabel: UILabel!
     
 }

--- a/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineTableViewCell.xib
+++ b/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineTableViewCell.xib
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -31,7 +29,7 @@
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YkH-X4-m8L">
-                        <rect key="frame" x="85" y="30" width="44" height="22"/>
+                        <rect key="frame" x="85" y="30.5" width="44" height="21"/>
                         <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="18"/>
                         <color key="textColor" name="black_sub"/>
                         <nil key="highlightedColor"/>
@@ -46,8 +44,8 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="addMedicineLabel" destination="YkH-X4-m8L" id="EqN-Fu-BRV"/>
                 <outlet property="medicineImageView" destination="8NO-48-d7F" id="Emo-mE-QgI"/>
+                <outlet property="medicineTextLabel" destination="YkH-X4-m8L" id="EqN-Fu-BRV"/>
             </connections>
             <point key="canvasLocation" x="204.34782608695653" y="182.14285714285714"/>
         </tableViewCell>

--- a/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineTableViewCell.xib
+++ b/SobokSobok/SobokSobok/Presentation/Medicine/AddMedicineSheet/AddMedicineTableViewCell.xib
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="Pretendard-Regular.otf">
+            <string>Pretendard-Regular</string>
+        </array>
+    </customFonts>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="194" id="KGk-i7-Jjw" customClass="AddMedicineTableViewCell" customModule="SobokSobok" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="420" height="194"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="420" height="194"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="8NO-48-d7F">
+                        <rect key="frame" x="25" y="19" width="44" height="44"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="44" id="NiI-fb-x09"/>
+                            <constraint firstAttribute="height" constant="44" id="UDf-fO-bvQ"/>
+                        </constraints>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YkH-X4-m8L">
+                        <rect key="frame" x="85" y="30" width="44" height="22"/>
+                        <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="18"/>
+                        <color key="textColor" name="black_sub"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="YkH-X4-m8L" firstAttribute="centerY" secondItem="8NO-48-d7F" secondAttribute="centerY" id="19L-lp-lPt"/>
+                    <constraint firstItem="8NO-48-d7F" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="19" id="6bL-qd-Pol"/>
+                    <constraint firstItem="8NO-48-d7F" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="25" id="Gaj-H4-Cx9"/>
+                    <constraint firstItem="YkH-X4-m8L" firstAttribute="leading" secondItem="8NO-48-d7F" secondAttribute="trailing" constant="16" id="Yd3-kA-B3h"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="addMedicineLabel" destination="YkH-X4-m8L" id="EqN-Fu-BRV"/>
+                <outlet property="medicineImageView" destination="8NO-48-d7F" id="Emo-mE-QgI"/>
+            </connections>
+            <point key="canvasLocation" x="204.34782608695653" y="182.14285714285714"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <namedColor name="black_sub">
+            <color red="0.12156862745098039" green="0.12549019607843137" blue="0.13333333333333333" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->
- 약 추가 바텀 시트 구현

🌱 작업한 브랜치

- feature/#12

🌱 작업한 내용

- Xib, UITableView를 활용한 바텀 시트 구현
- 구분선
- 셀 클릭했을 때 회색 X
- separator inset left -> 0
- didSelectRow 부분은 나머지 뷰 짜면 추가 예정
- 팝업 만들듯이 Background Black -> Opacity 값을 수정 (추후 디자인과 얘기해서 수정 예정)

## 📸 스크린샷

![스크린샷 2022-01-10 오전 12 39 37](https://user-images.githubusercontent.com/80672561/148689632-87150aed-d347-469d-ae8b-5b80dec0320d.png)


## 📮 관련 이슈

- Resolved: #12
