### PR TITLE
[#28] 홈 뷰 UI 영역 잡기

### DIFF
--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -31,10 +31,10 @@
 		BD64F8F42788B488009249D0 /* Pretendard-ExtraLight.otf in Resources */ = {isa = PBXBuildFile; fileRef = BD64F8EF2788B488009249D0 /* Pretendard-ExtraLight.otf */; };
 		BDD21A9A278D8705007D10F6 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD21A98278D8705007D10F6 /* HomeViewController.swift */; };
 		BDD21A9B278D8705007D10F6 /* HomeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BDD21A99278D8705007D10F6 /* HomeViewController.xib */; };
-		BDD21A9E278D8F82007D10F6 /* TimeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD21A9D278D8F82007D10F6 /* TimeHeaderView.swift */; };
-		BDD21AA0278D8F94007D10F6 /* TimeHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BDD21A9F278D8F94007D10F6 /* TimeHeaderView.xib */; };
 		BDD21AA3278D92B2007D10F6 /* MedicineCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD21AA1278D92B2007D10F6 /* MedicineCollectionViewCell.swift */; };
 		BDD21AA4278D92B2007D10F6 /* MedicineCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BDD21AA2278D92B2007D10F6 /* MedicineCollectionViewCell.xib */; };
+		BDD21AA7278DA85B007D10F6 /* TimeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD21AA5278DA85B007D10F6 /* TimeHeaderView.swift */; };
+		BDD21AA8278DA85B007D10F6 /* TimeHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BDD21AA6278DA85B007D10F6 /* TimeHeaderView.xib */; };
 		BDDAA581278997E1000C0AF8 /* Color.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA580278997E1000C0AF8 /* Color.xcassets */; };
 		BDDAA58327899C25000C0AF8 /* Image.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA58227899C25000C0AF8 /* Image.xcassets */; };
 		BDDAA5952789B2A2000C0AF8 /* generate.py in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA5942789B2A2000C0AF8 /* generate.py */; };
@@ -81,10 +81,10 @@
 		BD64F8EF2788B488009249D0 /* Pretendard-ExtraLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-ExtraLight.otf"; sourceTree = "<group>"; };
 		BDD21A98278D8705007D10F6 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		BDD21A99278D8705007D10F6 /* HomeViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HomeViewController.xib; sourceTree = "<group>"; };
-		BDD21A9D278D8F82007D10F6 /* TimeHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimeHeaderView.swift; path = SobokSobok/Presentation/Home/TimeHeaderView.swift; sourceTree = SOURCE_ROOT; };
-		BDD21A9F278D8F94007D10F6 /* TimeHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = TimeHeaderView.xib; path = SobokSobok/Presentation/Home/TimeHeaderView.xib; sourceTree = SOURCE_ROOT; };
 		BDD21AA1278D92B2007D10F6 /* MedicineCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MedicineCollectionViewCell.swift; path = SobokSobok/Presentation/Home/MedicineCollectionViewCell.swift; sourceTree = SOURCE_ROOT; };
 		BDD21AA2278D92B2007D10F6 /* MedicineCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = MedicineCollectionViewCell.xib; path = SobokSobok/Presentation/Home/MedicineCollectionViewCell.xib; sourceTree = SOURCE_ROOT; };
+		BDD21AA5278DA85B007D10F6 /* TimeHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimeHeaderView.swift; path = SobokSobok/Presentation/Home/TimeHeaderView.swift; sourceTree = SOURCE_ROOT; };
+		BDD21AA6278DA85B007D10F6 /* TimeHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = TimeHeaderView.xib; path = SobokSobok/Presentation/Home/TimeHeaderView.xib; sourceTree = SOURCE_ROOT; };
 		BDDAA580278997E1000C0AF8 /* Color.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Color.xcassets; sourceTree = "<group>"; };
 		BDDAA58227899C25000C0AF8 /* Image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Image.xcassets; sourceTree = "<group>"; };
 		BDDAA5942789B2A2000C0AF8 /* generate.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = generate.py; sourceTree = "<group>"; };
@@ -422,10 +422,10 @@
 		BDD21A9C278D8E35007D10F6 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				BDD21A9D278D8F82007D10F6 /* TimeHeaderView.swift */,
-				BDD21A9F278D8F94007D10F6 /* TimeHeaderView.xib */,
 				BDD21AA1278D92B2007D10F6 /* MedicineCollectionViewCell.swift */,
 				BDD21AA2278D92B2007D10F6 /* MedicineCollectionViewCell.xib */,
+				BDD21AA5278DA85B007D10F6 /* TimeHeaderView.swift */,
+				BDD21AA6278DA85B007D10F6 /* TimeHeaderView.xib */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -532,6 +532,7 @@
 			files = (
 				BDD21AA4278D92B2007D10F6 /* MedicineCollectionViewCell.xib in Resources */,
 				BD64F8F42788B488009249D0 /* Pretendard-ExtraLight.otf in Resources */,
+				BDD21AA8278DA85B007D10F6 /* TimeHeaderView.xib in Resources */,
 				BD64F8EA2788A01C009249D0 /* .swiftlint.yml in Resources */,
 				BD64F8F02788B488009249D0 /* Pretendard-Bold.otf in Resources */,
 				BD64F8F22788B488009249D0 /* Pretendard-SemiBold.otf in Resources */,
@@ -542,7 +543,6 @@
 				BD515E42278770C7003BD5A4 /* Assets.xcassets in Resources */,
 				F67CDBF6278D46EA00F70974 /* NavigationBarView.xib in Resources */,
 				BD64F8F32788B488009249D0 /* Pretendard-Regular.otf in Resources */,
-				BDD21AA0278D8F94007D10F6 /* TimeHeaderView.xib in Resources */,
 				EC037613278B2EAF00CA4B54 /* AddMedicineTableViewCell.xib in Resources */,
 				BDDAA581278997E1000C0AF8 /* Color.xcassets in Resources */,
 				BDDAA58327899C25000C0AF8 /* Image.xcassets in Resources */,
@@ -607,12 +607,12 @@
 				BDDAA5AB2789BCD3000C0AF8 /* Image.swift in Sources */,
 				BDDAA5AC2789BCD3000C0AF8 /* URL.swift in Sources */,
 				F69CAA4C2789EFF60035230D /* NoticeTableViewCell.swift in Sources */,
+				BDD21AA7278DA85B007D10F6 /* TimeHeaderView.swift in Sources */,
 				F67CDBF2278B4B8D00F70974 /* NoticeListDataModel.swift in Sources */,
 				BDDAA5AD2789BCD3000C0AF8 /* Color.swift in Sources */,
 				BD515E72278778F9003BD5A4 /* SampleViewController.swift in Sources */,
 				BD515E39278770C5003BD5A4 /* AppDelegate.swift in Sources */,
 				BD149DCB278B31DC009AA416 /* TabBarItem.swift in Sources */,
-				BDD21A9E278D8F82007D10F6 /* TimeHeaderView.swift in Sources */,
 				BDDAA5AA2789BCD3000C0AF8 /* Notification.swift in Sources */,
 				F6538FA5278D7DD600B20B5E /* NavigationBarView.swift in Sources */,
 				BD515E3B278770C5003BD5A4 /* SceneDelegate.swift in Sources */,

--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		BD64F8F42788B488009249D0 /* Pretendard-ExtraLight.otf in Resources */ = {isa = PBXBuildFile; fileRef = BD64F8EF2788B488009249D0 /* Pretendard-ExtraLight.otf */; };
 		BDD21A9A278D8705007D10F6 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD21A98278D8705007D10F6 /* HomeViewController.swift */; };
 		BDD21A9B278D8705007D10F6 /* HomeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BDD21A99278D8705007D10F6 /* HomeViewController.xib */; };
+		BDD21A9E278D8F82007D10F6 /* TimeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD21A9D278D8F82007D10F6 /* TimeHeaderView.swift */; };
+		BDD21AA0278D8F94007D10F6 /* TimeHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BDD21A9F278D8F94007D10F6 /* TimeHeaderView.xib */; };
 		BDDAA581278997E1000C0AF8 /* Color.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA580278997E1000C0AF8 /* Color.xcassets */; };
 		BDDAA58327899C25000C0AF8 /* Image.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA58227899C25000C0AF8 /* Image.xcassets */; };
 		BDDAA5952789B2A2000C0AF8 /* generate.py in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA5942789B2A2000C0AF8 /* generate.py */; };
@@ -77,6 +79,8 @@
 		BD64F8EF2788B488009249D0 /* Pretendard-ExtraLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-ExtraLight.otf"; sourceTree = "<group>"; };
 		BDD21A98278D8705007D10F6 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		BDD21A99278D8705007D10F6 /* HomeViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HomeViewController.xib; sourceTree = "<group>"; };
+		BDD21A9D278D8F82007D10F6 /* TimeHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimeHeaderView.swift; path = SobokSobok/Presentation/Home/TimeHeaderView.swift; sourceTree = SOURCE_ROOT; };
+		BDD21A9F278D8F94007D10F6 /* TimeHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = TimeHeaderView.xib; path = SobokSobok/Presentation/Home/TimeHeaderView.xib; sourceTree = SOURCE_ROOT; };
 		BDDAA580278997E1000C0AF8 /* Color.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Color.xcassets; sourceTree = "<group>"; };
 		BDDAA58227899C25000C0AF8 /* Image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Image.xcassets; sourceTree = "<group>"; };
 		BDDAA5942789B2A2000C0AF8 /* generate.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = generate.py; sourceTree = "<group>"; };
@@ -362,6 +366,7 @@
 		BD515E67278776D5003BD5A4 /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				BDD21A9C278D8E35007D10F6 /* Views */,
 				BDD21A98278D8705007D10F6 /* HomeViewController.swift */,
 				BDD21A99278D8705007D10F6 /* HomeViewController.xib */,
 			);
@@ -408,6 +413,15 @@
 				BD515E71278778F9003BD5A4 /* SampleViewController.xib */,
 			);
 			path = Sample;
+			sourceTree = "<group>";
+		};
+		BDD21A9C278D8E35007D10F6 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				BDD21A9D278D8F82007D10F6 /* TimeHeaderView.swift */,
+				BDD21A9F278D8F94007D10F6 /* TimeHeaderView.xib */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		BDDAA5932789B271000C0AF8 /* Script */ = {
@@ -521,6 +535,7 @@
 				BD515E42278770C7003BD5A4 /* Assets.xcassets in Resources */,
 				F67CDBF6278D46EA00F70974 /* NavigationBarView.xib in Resources */,
 				BD64F8F32788B488009249D0 /* Pretendard-Regular.otf in Resources */,
+				BDD21AA0278D8F94007D10F6 /* TimeHeaderView.xib in Resources */,
 				EC037613278B2EAF00CA4B54 /* AddMedicineTableViewCell.xib in Resources */,
 				BDDAA581278997E1000C0AF8 /* Color.xcassets in Resources */,
 				BDDAA58327899C25000C0AF8 /* Image.xcassets in Resources */,
@@ -589,6 +604,7 @@
 				BD515E72278778F9003BD5A4 /* SampleViewController.swift in Sources */,
 				BD515E39278770C5003BD5A4 /* AppDelegate.swift in Sources */,
 				BD149DCB278B31DC009AA416 /* TabBarItem.swift in Sources */,
+				BDD21A9E278D8F82007D10F6 /* TimeHeaderView.swift in Sources */,
 				BDDAA5AA2789BCD3000C0AF8 /* Notification.swift in Sources */,
 				F6538FA5278D7DD600B20B5E /* NavigationBarView.swift in Sources */,
 				BD515E3B278770C5003BD5A4 /* SceneDelegate.swift in Sources */,

--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		BD64F8F22788B488009249D0 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = BD64F8ED2788B487009249D0 /* Pretendard-SemiBold.otf */; };
 		BD64F8F32788B488009249D0 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = BD64F8EE2788B487009249D0 /* Pretendard-Regular.otf */; };
 		BD64F8F42788B488009249D0 /* Pretendard-ExtraLight.otf in Resources */ = {isa = PBXBuildFile; fileRef = BD64F8EF2788B488009249D0 /* Pretendard-ExtraLight.otf */; };
+		BDD21A9A278D8705007D10F6 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD21A98278D8705007D10F6 /* HomeViewController.swift */; };
+		BDD21A9B278D8705007D10F6 /* HomeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BDD21A99278D8705007D10F6 /* HomeViewController.xib */; };
 		BDDAA581278997E1000C0AF8 /* Color.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA580278997E1000C0AF8 /* Color.xcassets */; };
 		BDDAA58327899C25000C0AF8 /* Image.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA58227899C25000C0AF8 /* Image.xcassets */; };
 		BDDAA5952789B2A2000C0AF8 /* generate.py in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA5942789B2A2000C0AF8 /* generate.py */; };
@@ -73,6 +75,8 @@
 		BD64F8ED2788B487009249D0 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		BD64F8EE2788B487009249D0 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		BD64F8EF2788B488009249D0 /* Pretendard-ExtraLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-ExtraLight.otf"; sourceTree = "<group>"; };
+		BDD21A98278D8705007D10F6 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		BDD21A99278D8705007D10F6 /* HomeViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HomeViewController.xib; sourceTree = "<group>"; };
 		BDDAA580278997E1000C0AF8 /* Color.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Color.xcassets; sourceTree = "<group>"; };
 		BDDAA58227899C25000C0AF8 /* Image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Image.xcassets; sourceTree = "<group>"; };
 		BDDAA5942789B2A2000C0AF8 /* generate.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = generate.py; sourceTree = "<group>"; };
@@ -358,6 +362,8 @@
 		BD515E67278776D5003BD5A4 /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				BDD21A98278D8705007D10F6 /* HomeViewController.swift */,
+				BDD21A99278D8705007D10F6 /* HomeViewController.xib */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -521,6 +527,7 @@
 				F69CAA472789EDE70035230D /* NoticeViewController.xib in Resources */,
 				BD515E73278778F9003BD5A4 /* SampleViewController.xib in Resources */,
 				BD64F8F12788B488009249D0 /* Pretendard-Light.otf in Resources */,
+				BDD21A9B278D8705007D10F6 /* HomeViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -585,6 +592,7 @@
 				BDDAA5AA2789BCD3000C0AF8 /* Notification.swift in Sources */,
 				F6538FA5278D7DD600B20B5E /* NavigationBarView.swift in Sources */,
 				BD515E3B278770C5003BD5A4 /* SceneDelegate.swift in Sources */,
+				BDD21A9A278D8705007D10F6 /* HomeViewController.swift in Sources */,
 				BDDAA5A92789BCD3000C0AF8 /* UserDefaultKey.swift in Sources */,
 				BDDAA5AE2789BCD3000C0AF8 /* Text.swift in Sources */,
 				F69CAA462789EDE70035230D /* NoticeViewController.swift in Sources */,

--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		BDD21A9B278D8705007D10F6 /* HomeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BDD21A99278D8705007D10F6 /* HomeViewController.xib */; };
 		BDD21A9E278D8F82007D10F6 /* TimeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD21A9D278D8F82007D10F6 /* TimeHeaderView.swift */; };
 		BDD21AA0278D8F94007D10F6 /* TimeHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BDD21A9F278D8F94007D10F6 /* TimeHeaderView.xib */; };
+		BDD21AA3278D92B2007D10F6 /* MedicineCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD21AA1278D92B2007D10F6 /* MedicineCollectionViewCell.swift */; };
+		BDD21AA4278D92B2007D10F6 /* MedicineCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BDD21AA2278D92B2007D10F6 /* MedicineCollectionViewCell.xib */; };
 		BDDAA581278997E1000C0AF8 /* Color.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA580278997E1000C0AF8 /* Color.xcassets */; };
 		BDDAA58327899C25000C0AF8 /* Image.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA58227899C25000C0AF8 /* Image.xcassets */; };
 		BDDAA5952789B2A2000C0AF8 /* generate.py in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA5942789B2A2000C0AF8 /* generate.py */; };
@@ -81,6 +83,8 @@
 		BDD21A99278D8705007D10F6 /* HomeViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HomeViewController.xib; sourceTree = "<group>"; };
 		BDD21A9D278D8F82007D10F6 /* TimeHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimeHeaderView.swift; path = SobokSobok/Presentation/Home/TimeHeaderView.swift; sourceTree = SOURCE_ROOT; };
 		BDD21A9F278D8F94007D10F6 /* TimeHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = TimeHeaderView.xib; path = SobokSobok/Presentation/Home/TimeHeaderView.xib; sourceTree = SOURCE_ROOT; };
+		BDD21AA1278D92B2007D10F6 /* MedicineCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MedicineCollectionViewCell.swift; path = SobokSobok/Presentation/Home/MedicineCollectionViewCell.swift; sourceTree = SOURCE_ROOT; };
+		BDD21AA2278D92B2007D10F6 /* MedicineCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = MedicineCollectionViewCell.xib; path = SobokSobok/Presentation/Home/MedicineCollectionViewCell.xib; sourceTree = SOURCE_ROOT; };
 		BDDAA580278997E1000C0AF8 /* Color.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Color.xcassets; sourceTree = "<group>"; };
 		BDDAA58227899C25000C0AF8 /* Image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Image.xcassets; sourceTree = "<group>"; };
 		BDDAA5942789B2A2000C0AF8 /* generate.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = generate.py; sourceTree = "<group>"; };
@@ -420,6 +424,8 @@
 			children = (
 				BDD21A9D278D8F82007D10F6 /* TimeHeaderView.swift */,
 				BDD21A9F278D8F94007D10F6 /* TimeHeaderView.xib */,
+				BDD21AA1278D92B2007D10F6 /* MedicineCollectionViewCell.swift */,
+				BDD21AA2278D92B2007D10F6 /* MedicineCollectionViewCell.xib */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -524,6 +530,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BDD21AA4278D92B2007D10F6 /* MedicineCollectionViewCell.xib in Resources */,
 				BD64F8F42788B488009249D0 /* Pretendard-ExtraLight.otf in Resources */,
 				BD64F8EA2788A01C009249D0 /* .swiftlint.yml in Resources */,
 				BD64F8F02788B488009249D0 /* Pretendard-Bold.otf in Resources */,
@@ -596,6 +603,7 @@
 				BD149DCD278B3369009AA416 /* TabBarController.swift in Sources */,
 				EC03760E278B2E4000CA4B54 /* AddMedicineSheet.swift in Sources */,
 				EC037612278B2EAF00CA4B54 /* AddMedicineTableViewCell.swift in Sources */,
+				BDD21AA3278D92B2007D10F6 /* MedicineCollectionViewCell.swift in Sources */,
 				BDDAA5AB2789BCD3000C0AF8 /* Image.swift in Sources */,
 				BDDAA5AC2789BCD3000C0AF8 /* URL.swift in Sources */,
 				F69CAA4C2789EFF60035230D /* NoticeTableViewCell.swift in Sources */,

--- a/SobokSobok/SobokSobok.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SobokSobok/SobokSobok.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/Taehyeon-Kim/EasyKit.git",
         "state": {
           "branch": "master",
-          "revision": "d92b5260733164b7ccefccbcbd50568abcfc9afb",
+          "revision": "f2d2d96a4450164e9089c2fad014e7cff8e7dc43",
           "version": null
         }
       },

--- a/SobokSobok/SobokSobok/Presentation/Common/BaseViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Common/BaseViewController.swift
@@ -16,7 +16,9 @@ class BaseViewController: UIViewController {
         layout()
     }
     
-    public func style() {}
+    public func style() {
+        navigationController?.navigationBar.isHidden = true
+    }
     public func hierarchy() {}
     public func layout() {}
 }

--- a/SobokSobok/SobokSobok/Presentation/Common/TabBarController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Common/TabBarController.swift
@@ -55,7 +55,7 @@ extension TabBarController {
 
     private func setTabBarItems() {
         tabs = [
-            UINavigationController(rootViewController: SampleViewController.instanceFromNib()),
+            UINavigationController(rootViewController: HomeViewController.instanceFromNib()),
             UINavigationController(rootViewController: SampleViewController.instanceFromNib()),
             UINavigationController(rootViewController: SampleViewController.instanceFromNib()),
             UINavigationController(rootViewController: UIViewController())

--- a/SobokSobok/SobokSobok/Presentation/Home/HomeViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Home/HomeViewController.swift
@@ -1,0 +1,17 @@
+//
+//  HomeViewController.swift
+//  SobokSobok
+//
+//  Created by taehy.k on 2022/01/11.
+//
+
+import UIKit
+
+final class HomeViewController: BaseViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+}

--- a/SobokSobok/SobokSobok/Presentation/Home/HomeViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Home/HomeViewController.swift
@@ -9,9 +9,88 @@ import UIKit
 
 final class HomeViewController: BaseViewController {
 
+    @IBOutlet private weak var collectionView: UICollectionView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        setCollectionView()
+        registerXibs()
+    }
+    
+    private func setCollectionView() {
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.backgroundColor = Color.gray150
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 32, right: 0)
+    }
+    
+    private func registerXibs() {
+        let nib = UINib(nibName: TimeHeaderView.nibName, bundle: nil)
+        collectionView.register(nib,
+                                forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+                                withReuseIdentifier: TimeHeaderView.reuseIdentifier)
+        collectionView.register(MedicineCollectionViewCell.self)
+    }
+}
+
+typealias CollectionViewDelegate = UICollectionViewDelegate & UICollectionViewDataSource
+
+extension HomeViewController: CollectionViewDelegate {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        3
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        4
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: MedicineCollectionViewCell.self)
+        cell.contentView.backgroundColor = Color.white
+        cell.contentView.makeRounded(radius: 12)
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        switch kind {
+        case UICollectionView.elementKindSectionHeader:
+            guard let headerView = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind,
+                withReuseIdentifier: TimeHeaderView.reuseIdentifier,
+                for: indexPath
+            ) as? TimeHeaderView else { return UICollectionReusableView() }
+            if indexPath.section == 0 {
+                headerView.editButtonStackView.isHidden = false
+            } else {
+                headerView.editButtonStackView.isHidden = true
+            }
+            return headerView
+        default:
+            assert(false, "헤더 뷰 찾을 수 없음")
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        let width: CGFloat = collectionView.frame.width
+        let height: CGFloat = 77
+        return CGSize(width: width, height: height)
+    }
+}
+
+extension HomeViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let screenWidth = UIScreen.main.bounds.width
+        let width = 335 / 375 * screenWidth
+        let height = width * 140 / 335
+        return CGSize(width: width, height: height)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        8
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
     }
 }

--- a/SobokSobok/SobokSobok/Presentation/Home/HomeViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/Home/HomeViewController.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="HomeViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/SobokSobok/SobokSobok/Presentation/Home/HomeViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/Home/HomeViewController.xib
@@ -17,6 +17,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="HomeViewController" customModule="SobokSobok" customModuleProvider="target">
             <connections>
+                <outlet property="collectionView" destination="3vW-CZ-vKz" id="yST-RI-Ho1"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -53,7 +54,7 @@
                         <constraint firstAttribute="height" constant="125" id="t7Z-rc-1kX"/>
                     </constraints>
                 </view>
-                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="3vW-CZ-vKz">
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="3vW-CZ-vKz">
                     <rect key="frame" x="0.0" y="316" width="375" height="462"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="n9Q-vp-i4N">

--- a/SobokSobok/SobokSobok/Presentation/Home/HomeViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/Home/HomeViewController.xib
@@ -1,22 +1,94 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="Pretendard-Bold.otf">
+            <string>Pretendard-Bold</string>
+        </array>
+    </customFonts>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="HomeViewController" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="HomeViewController" customModule="SobokSobok" customModuleProvider="target">
             <connections>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dmZ-M0-7jP">
+                    <rect key="frame" x="20" y="84" width="281.66666666666669" height="70"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="70" id="mGh-AP-HPb"/>
+                    </constraints>
+                    <string key="text">소중한 닉네임이10글자네요님
+오늘도 약 꼭 챙겨 드세요</string>
+                    <fontDescription key="fontDescription" name="Pretendard-Bold" family="Pretendard" pointSize="24"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QvT-Hn-6Yo">
+                    <rect key="frame" x="320" y="72" width="48" height="48"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="48" id="etm-4g-yAG"/>
+                        <constraint firstAttribute="width" constant="48" id="tiK-HR-yWc"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                    <state key="normal" image="icMenu48"/>
+                </button>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CMt-Za-RPJ">
+                    <rect key="frame" x="0.0" y="191" width="375" height="125"/>
+                    <color key="backgroundColor" name="middle_mint_main"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="125" id="t7Z-rc-1kX"/>
+                    </constraints>
+                </view>
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="3vW-CZ-vKz">
+                    <rect key="frame" x="0.0" y="316" width="375" height="462"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="n9Q-vp-i4N">
+                        <size key="itemSize" width="128" height="128"/>
+                        <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                        <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                        <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                    </collectionViewFlowLayout>
+                </collectionView>
+            </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="dmZ-M0-7jP" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="3iQ-Jw-c5b"/>
+                <constraint firstItem="3vW-CZ-vKz" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Gfw-Sl-fQb"/>
+                <constraint firstItem="CMt-Za-RPJ" firstAttribute="top" secondItem="dmZ-M0-7jP" secondAttribute="bottom" constant="37" id="Mhg-Gl-zUX"/>
+                <constraint firstItem="dmZ-M0-7jP" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="84" id="WJO-bO-kkq"/>
+                <constraint firstItem="3vW-CZ-vKz" firstAttribute="top" secondItem="CMt-Za-RPJ" secondAttribute="bottom" id="YU8-YA-QPn"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="CMt-Za-RPJ" secondAttribute="trailing" id="ZZq-Cf-5AR"/>
+                <constraint firstItem="CMt-Za-RPJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="ZjW-Y2-liT"/>
+                <constraint firstItem="QvT-Hn-6Yo" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="28" id="ca5-Am-is4"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="QvT-Hn-6Yo" secondAttribute="trailing" constant="7" id="d2e-xT-8nO"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="3vW-CZ-vKz" secondAttribute="bottom" id="ddw-dU-7hn"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="3vW-CZ-vKz" secondAttribute="trailing" id="lyY-0c-CpP"/>
+            </constraints>
+            <point key="canvasLocation" x="139" y="147"/>
         </view>
     </objects>
+    <resources>
+        <image name="icMenu48" width="48" height="48"/>
+        <namedColor name="middle_mint_main">
+            <color red="0.55294117647058827" green="0.92156862745098034" blue="0.90588235294117647" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SobokSobok/SobokSobok/Presentation/Home/MedicineCollectionViewCell.swift
+++ b/SobokSobok/SobokSobok/Presentation/Home/MedicineCollectionViewCell.swift
@@ -1,0 +1,17 @@
+//
+//  MedicineCollectionViewCell.swift
+//  SobokSobok
+//
+//  Created by taehy.k on 2022/01/11.
+//
+
+import UIKit
+
+final class MedicineCollectionViewCell: UICollectionViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+}

--- a/SobokSobok/SobokSobok/Presentation/Home/MedicineCollectionViewCell.swift
+++ b/SobokSobok/SobokSobok/Presentation/Home/MedicineCollectionViewCell.swift
@@ -13,5 +13,4 @@ final class MedicineCollectionViewCell: UICollectionViewCell {
         super.awakeFromNib()
         // Initialization code
     }
-
 }

--- a/SobokSobok/SobokSobok/Presentation/Home/MedicineCollectionViewCell.xib
+++ b/SobokSobok/SobokSobok/Presentation/Home/MedicineCollectionViewCell.xib
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="Pretendard-Regular.otf">
+            <string>Pretendard-Regular</string>
+        </array>
+    </customFonts>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="MedicineCollectionViewCell" customModule="SobokSobok" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="140"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="140"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="16E-3I-gZV">
+                        <rect key="frame" x="20" y="28" width="8" height="8"/>
+                        <color key="backgroundColor" name="pill_color_red"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="8" id="C3T-7n-Iqy"/>
+                            <constraint firstAttribute="width" constant="8" id="dCt-f7-yHg"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                <real key="value" value="4"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </view>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aO4-eb-Fdi">
+                        <rect key="frame" x="315" y="4" width="56" height="56"/>
+                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                        <state key="normal" image="icCheckUnselect56"/>
+                    </button>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="약 명이 10글자일 땐 이렇게" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zyw-hg-RmU">
+                        <rect key="frame" x="38.000000000000014" y="19" width="192.33333333333337" height="26"/>
+                        <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="18"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="fIT-t6-iIT" userLabel="Sticker Stack View">
+                        <rect key="frame" x="16" y="57" width="267" height="63"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rlt-84-F1Q">
+                                <rect key="frame" x="0.0" y="0.0" width="63" height="63"/>
+                                <color key="backgroundColor" name="pill_color_blue"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="63" id="pCo-kF-5wf"/>
+                                    <constraint firstAttribute="width" constant="63" id="wx8-yO-e8Q"/>
+                                </constraints>
+                            </imageView>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="WPI-WR-U9B">
+                                <rect key="frame" x="68" y="0.0" width="63" height="63"/>
+                                <color key="backgroundColor" name="pill_color_orange"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="63" id="j5l-Tq-yn4"/>
+                                    <constraint firstAttribute="height" constant="63" id="omY-kr-Kuw"/>
+                                </constraints>
+                            </imageView>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="QQQ-Ru-Wl7">
+                                <rect key="frame" x="136" y="0.0" width="63" height="63"/>
+                                <color key="backgroundColor" name="pill_color_pink"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="63" id="Wwf-QM-dZK"/>
+                                    <constraint firstAttribute="height" constant="63" id="pjq-Fx-N2I"/>
+                                </constraints>
+                            </imageView>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="IhF-Is-kQi">
+                                <rect key="frame" x="204" y="0.0" width="63" height="63"/>
+                                <color key="backgroundColor" name="pill_color_red"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="63" id="LId-sx-cXw"/>
+                                    <constraint firstAttribute="height" constant="63" id="tEp-VI-ddy"/>
+                                </constraints>
+                            </imageView>
+                        </subviews>
+                    </stackView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+ 5" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KlU-Y2-XsV">
+                        <rect key="frame" x="334.66666666666669" y="108.66666666666667" width="22.333333333333314" height="18.333333333333329"/>
+                        <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="15"/>
+                        <color key="textColor" name="gray600_sub"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+            </view>
+            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="fIT-t6-iIT" secondAttribute="bottom" constant="20" id="4oO-RL-Te1"/>
+                <constraint firstItem="zyw-hg-RmU" firstAttribute="leading" secondItem="16E-3I-gZV" secondAttribute="trailing" constant="10" id="AVH-Ta-1Z6"/>
+                <constraint firstItem="fIT-t6-iIT" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="16" id="HXB-q8-d8n"/>
+                <constraint firstItem="16E-3I-gZV" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="28" id="KRn-AN-Xzm"/>
+                <constraint firstItem="fIT-t6-iIT" firstAttribute="top" secondItem="zyw-hg-RmU" secondAttribute="bottom" constant="12" id="KXL-3N-G16"/>
+                <constraint firstAttribute="bottom" secondItem="KlU-Y2-XsV" secondAttribute="bottom" constant="13" id="NT9-cN-mJa"/>
+                <constraint firstItem="zyw-hg-RmU" firstAttribute="centerY" secondItem="16E-3I-gZV" secondAttribute="centerY" id="Pdg-w2-YaO"/>
+                <constraint firstAttribute="trailing" secondItem="aO4-eb-Fdi" secondAttribute="trailing" constant="4" id="RUQ-8G-6Ay"/>
+                <constraint firstItem="aO4-eb-Fdi" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="4" id="eLd-OX-QqA"/>
+                <constraint firstAttribute="trailing" secondItem="KlU-Y2-XsV" secondAttribute="trailing" constant="18" id="g5M-Xr-oc1"/>
+                <constraint firstItem="16E-3I-gZV" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="20" id="pHd-nZ-fR9"/>
+            </constraints>
+            <size key="customSize" width="391" height="123"/>
+            <point key="canvasLocation" x="77.536231884057983" y="145.98214285714286"/>
+        </collectionViewCell>
+    </objects>
+    <resources>
+        <image name="icCheckUnselect56" width="56" height="56"/>
+        <namedColor name="gray600_sub">
+            <color red="0.51764705882352946" green="0.5490196078431373" blue="0.5725490196078431" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="pill_color_blue">
+            <color red="0.32941176470588235" green="0.67843137254901964" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="pill_color_orange">
+            <color red="1" green="0.59999999999999998" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="pill_color_pink">
+            <color red="1" green="0.40392156862745099" blue="0.76078431372549016" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="pill_color_red">
+            <color red="1" green="0.36078431372549019" blue="0.36078431372549019" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/SobokSobok/SobokSobok/Presentation/Home/TimeHeaderView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Home/TimeHeaderView.swift
@@ -8,5 +8,15 @@
 import UIKit
 
 final class TimeHeaderView: UICollectionReusableView {
+    
+    @IBOutlet weak var editButtonStackView: UIStackView!
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+    
+    override func prepareForReuse() {
+        editButtonStackView.isHidden = false
+    }
 }

--- a/SobokSobok/SobokSobok/Presentation/Home/TimeHeaderView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Home/TimeHeaderView.swift
@@ -1,0 +1,12 @@
+//
+//  TimeHeaderView.swift
+//  SobokSobok
+//
+//  Created by taehy.k on 2022/01/11.
+//
+
+import UIKit
+
+final class TimeHeaderView: UICollectionReusableView {
+
+}

--- a/SobokSobok/SobokSobok/Presentation/Home/TimeHeaderView.xib
+++ b/SobokSobok/SobokSobok/Presentation/Home/TimeHeaderView.xib
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="Pretendard-SemiBold.otf">
+            <string>Pretendard-SemiBold</string>
+        </array>
+    </customFonts>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TimeHeaderView" customModule="SobokSobok" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="77"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="오후 12:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9dM-IY-5tz">
+                    <rect key="frame" x="20" y="36" width="104" height="35"/>
+                    <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="23"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QAp-gG-nZJ">
+                    <rect key="frame" x="368" y="19" width="26" height="24"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hPe-YT-81t">
+                            <rect key="frame" x="0.0" y="0.0" width="26" height="23"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="23" id="44Z-wX-xwp"/>
+                                <constraint firstAttribute="width" constant="26" id="71G-BA-V9W"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" name="Pretendard-SemiBold" family="Pretendard" pointSize="15"/>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" title="수정">
+                                <color key="titleColor" name="gray700_sub"/>
+                            </state>
+                        </button>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D8u-Kw-HYl">
+                            <rect key="frame" x="0.0" y="23" width="26" height="1"/>
+                            <color key="backgroundColor" name="gray700_sub"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="1" id="WNT-Sa-B7m"/>
+                                <constraint firstAttribute="width" constant="26" id="uPK-OM-XJT"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="QAp-gG-nZJ" secondAttribute="trailing" constant="20" id="0xa-Nt-bGc"/>
+                <constraint firstItem="9dM-IY-5tz" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" id="5Fl-c4-9dY"/>
+                <constraint firstItem="9dM-IY-5tz" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="36" id="Phx-ew-9iu"/>
+                <constraint firstAttribute="bottom" secondItem="9dM-IY-5tz" secondAttribute="bottom" constant="6" id="sfT-07-uAi"/>
+                <constraint firstItem="QAp-gG-nZJ" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="19" id="z2q-rW-zzJ"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="137.59999999999999" y="-145.19704433497537"/>
+        </view>
+    </objects>
+    <resources>
+        <namedColor name="gray700_sub">
+            <color red="0.40392156862745099" green="0.43137254901960786" blue="0.45490196078431372" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/SobokSobok/SobokSobok/Presentation/Home/TimeHeaderView.xib
+++ b/SobokSobok/SobokSobok/Presentation/Home/TimeHeaderView.xib
@@ -5,71 +5,74 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
+        <array key="Pretendard-Bold.otf">
+            <string>Pretendard-Bold</string>
+        </array>
         <array key="Pretendard-SemiBold.otf">
             <string>Pretendard-SemiBold</string>
         </array>
     </customFonts>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TimeHeaderView" customModule="SobokSobok" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="77"/>
-            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+        <collectionReusableView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="U6b-Vx-4bR" customClass="TimeHeaderView" customModule="SobokSobok" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="77"/>
+            <autoresizingMask key="autoresizingMask"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="오후 12:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9dM-IY-5tz">
-                    <rect key="frame" x="20" y="36" width="104" height="35"/>
-                    <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="23"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="오전 12:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DTP-LB-Qpk">
+                    <rect key="frame" x="20" y="36" width="107" height="35"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="35" id="yRA-9Z-sZ1"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" name="Pretendard-Bold" family="Pretendard" pointSize="23"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QAp-gG-nZJ">
-                    <rect key="frame" x="368" y="19" width="26" height="24"/>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="gMu-uv-txo">
+                    <rect key="frame" x="329" y="19" width="26" height="24"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hPe-YT-81t">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="수정" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kCc-gK-lew">
                             <rect key="frame" x="0.0" y="0.0" width="26" height="23"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="23" id="44Z-wX-xwp"/>
-                                <constraint firstAttribute="width" constant="26" id="71G-BA-V9W"/>
+                                <constraint firstAttribute="height" constant="23" id="1UP-DT-ATe"/>
+                                <constraint firstAttribute="width" constant="26" id="wD8-RR-oxM"/>
                             </constraints>
                             <fontDescription key="fontDescription" name="Pretendard-SemiBold" family="Pretendard" pointSize="15"/>
-                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                            <state key="normal" title="수정">
-                                <color key="titleColor" name="gray700_sub"/>
-                            </state>
-                        </button>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D8u-Kw-HYl">
+                            <color key="textColor" name="gray700_sub"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cNe-UM-zMd">
                             <rect key="frame" x="0.0" y="23" width="26" height="1"/>
                             <color key="backgroundColor" name="gray700_sub"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="1" id="WNT-Sa-B7m"/>
-                                <constraint firstAttribute="width" constant="26" id="uPK-OM-XJT"/>
+                                <constraint firstAttribute="width" constant="26" id="DoF-mW-iNK"/>
+                                <constraint firstAttribute="height" constant="1" id="dfh-ER-huB"/>
                             </constraints>
                         </view>
                     </subviews>
                 </stackView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <viewLayoutGuide key="safeArea" id="VXr-Tz-HHm"/>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="QAp-gG-nZJ" secondAttribute="trailing" constant="20" id="0xa-Nt-bGc"/>
-                <constraint firstItem="9dM-IY-5tz" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" id="5Fl-c4-9dY"/>
-                <constraint firstItem="9dM-IY-5tz" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="36" id="Phx-ew-9iu"/>
-                <constraint firstAttribute="bottom" secondItem="9dM-IY-5tz" secondAttribute="bottom" constant="6" id="sfT-07-uAi"/>
-                <constraint firstItem="QAp-gG-nZJ" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="19" id="z2q-rW-zzJ"/>
+                <constraint firstItem="DTP-LB-Qpk" firstAttribute="top" secondItem="U6b-Vx-4bR" secondAttribute="top" constant="36" id="020-VA-IUH"/>
+                <constraint firstItem="DTP-LB-Qpk" firstAttribute="leading" secondItem="VXr-Tz-HHm" secondAttribute="leading" constant="20" id="3BF-Mz-PqT"/>
+                <constraint firstItem="VXr-Tz-HHm" firstAttribute="bottom" secondItem="DTP-LB-Qpk" secondAttribute="bottom" constant="6" id="Gxg-ek-Rkh"/>
+                <constraint firstItem="gMu-uv-txo" firstAttribute="top" secondItem="U6b-Vx-4bR" secondAttribute="top" constant="19" id="Z35-EG-kCO"/>
+                <constraint firstAttribute="trailing" secondItem="gMu-uv-txo" secondAttribute="trailing" constant="20" id="eHU-m4-UZl"/>
             </constraints>
-            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="137.59999999999999" y="-145.19704433497537"/>
-        </view>
+            <connections>
+                <outlet property="editButtonStackView" destination="gMu-uv-txo" id="YWJ-md-rrA"/>
+            </connections>
+            <point key="canvasLocation" x="-8.8000000000000007" y="-100.86206896551725"/>
+        </collectionReusableView>
     </objects>
     <resources>
         <namedColor name="gray700_sub">
             <color red="0.40392156862745099" green="0.43137254901960786" blue="0.45490196078431372" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->

캘린더 부분을 제외한 홈 뷰의 UI 영역을 러프하게 구현합니다.

🌱 작업한 브랜치

- feature/#28

🌱 작업한 내용

- TimeHeaderView 작업
- MedicineCollectionViewCell 작업
- CollectionView 연결
- HomeViewController 탭 바 연결

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | ![Simulator Screen Recording - iPhone 13 mini - 2022-01-12 at 00 41 16](https://user-images.githubusercontent.com/61109660/148976980-cc6bf18f-76e0-44ab-b48d-eb172bd7a913.gif)|

## 📮 관련 이슈

- Resolved: #28
