### PR TITLE
[#31] 공유탭 UI 영역 구현

### DIFF
--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		BD149DCB278B31DC009AA416 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD149DCA278B31DC009AA416 /* TabBarItem.swift */; };
 		BD149DCD278B3369009AA416 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD149DCC278B3369009AA416 /* TabBarController.swift */; };
+		BD14F364278EB4B000F316AF /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD14F362278EB4B000F316AF /* ShareViewController.swift */; };
+		BD14F365278EB4B000F316AF /* ShareViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD14F363278EB4B000F316AF /* ShareViewController.xib */; };
 		BD515E39278770C5003BD5A4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD515E38278770C5003BD5A4 /* AppDelegate.swift */; };
 		BD515E3B278770C5003BD5A4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD515E3A278770C5003BD5A4 /* SceneDelegate.swift */; };
 		BD515E42278770C7003BD5A4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD515E41278770C7003BD5A4 /* Assets.xcassets */; };
@@ -63,6 +65,8 @@
 /* Begin PBXFileReference section */
 		BD149DCA278B31DC009AA416 /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
 		BD149DCC278B3369009AA416 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
+		BD14F362278EB4B000F316AF /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		BD14F363278EB4B000F316AF /* ShareViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ShareViewController.xib; sourceTree = "<group>"; };
 		BD515E35278770C5003BD5A4 /* SobokSobok.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SobokSobok.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD515E38278770C5003BD5A4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BD515E3A278770C5003BD5A4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -380,6 +384,8 @@
 		BD515E68278776E0003BD5A4 /* Share */ = {
 			isa = PBXGroup;
 			children = (
+				BD14F362278EB4B000F316AF /* ShareViewController.swift */,
+				BD14F363278EB4B000F316AF /* ShareViewController.xib */,
 			);
 			path = Share;
 			sourceTree = "<group>";
@@ -531,6 +537,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BDD21AA4278D92B2007D10F6 /* MedicineCollectionViewCell.xib in Resources */,
+				BD14F365278EB4B000F316AF /* ShareViewController.xib in Resources */,
 				BD64F8F42788B488009249D0 /* Pretendard-ExtraLight.otf in Resources */,
 				BDD21AA8278DA85B007D10F6 /* TimeHeaderView.xib in Resources */,
 				BD64F8EA2788A01C009249D0 /* .swiftlint.yml in Resources */,
@@ -611,6 +618,7 @@
 				F67CDBF2278B4B8D00F70974 /* NoticeListDataModel.swift in Sources */,
 				BDDAA5AD2789BCD3000C0AF8 /* Color.swift in Sources */,
 				BD515E72278778F9003BD5A4 /* SampleViewController.swift in Sources */,
+				BD14F364278EB4B000F316AF /* ShareViewController.swift in Sources */,
 				BD515E39278770C5003BD5A4 /* AppDelegate.swift in Sources */,
 				BD149DCB278B31DC009AA416 /* TabBarItem.swift in Sources */,
 				BDDAA5AA2789BCD3000C0AF8 /* Notification.swift in Sources */,

--- a/SobokSobok/SobokSobok/Presentation/Common/TabBarController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Common/TabBarController.swift
@@ -56,7 +56,7 @@ extension TabBarController {
     private func setTabBarItems() {
         tabs = [
             UINavigationController(rootViewController: HomeViewController.instanceFromNib()),
-            UINavigationController(rootViewController: SampleViewController.instanceFromNib()),
+            UINavigationController(rootViewController: ShareViewController.instanceFromNib()),
             UINavigationController(rootViewController: SampleViewController.instanceFromNib()),
             UINavigationController(rootViewController: UIViewController())
         ]

--- a/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.swift
@@ -1,0 +1,29 @@
+//
+//  ShareViewController.swift
+//  SobokSobok
+//
+//  Created by taehy.k on 2022/01/12.
+//
+
+import UIKit
+
+class ShareViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.swift
@@ -7,23 +7,84 @@
 
 import UIKit
 
-class ShareViewController: UIViewController {
+final class ShareViewController: UIViewController {
 
+    @IBOutlet private weak var collectionView: UICollectionView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        setCollectionView()
+        registerXibs()
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    
+    private func setCollectionView() {
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.backgroundColor = Color.gray150
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 32, right: 0)
     }
-    */
+    
+    private func registerXibs() {
+        let nib = UINib(nibName: TimeHeaderView.nibName, bundle: nil)
+        collectionView.register(nib,
+                                forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+                                withReuseIdentifier: TimeHeaderView.reuseIdentifier)
+        collectionView.register(MedicineCollectionViewCell.self)
+    }
+}
 
+extension ShareViewController: CollectionViewDelegate {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        3
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        4
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: MedicineCollectionViewCell.self)
+        cell.contentView.backgroundColor = Color.white
+        cell.contentView.makeRounded(radius: 12)
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        switch kind {
+        case UICollectionView.elementKindSectionHeader:
+            guard let headerView = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind,
+                withReuseIdentifier: TimeHeaderView.reuseIdentifier,
+                for: indexPath
+            ) as? TimeHeaderView else { return UICollectionReusableView() }
+            headerView.editButtonStackView.isHidden = true
+            return headerView
+        default:
+            assert(false, "헤더 뷰 찾을 수 없음")
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        let width: CGFloat = collectionView.frame.width
+        let height: CGFloat = 77
+        return CGSize(width: width, height: height)
+    }
+}
+
+extension ShareViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let screenWidth = UIScreen.main.bounds.width
+        let width = 335 / 375 * screenWidth
+        let height = width * 140 / 335
+        return CGSize(width: width, height: height)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        8
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+    }
 }

--- a/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.xib
@@ -1,22 +1,186 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="Pretendard-Bold.otf">
+            <string>Pretendard-Bold</string>
+        </array>
+    </customFonts>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ShareViewController" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ShareViewController" customModule="SobokSobok" customModuleProvider="target">
             <connections>
+                <outlet property="collectionView" destination="mT1-S7-pLf" id="08D-sX-IuO"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lmz-WE-XjL">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="123"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" spacing="22" translatesAutoresizingMaskIntoConstraints="NO" id="AsE-uB-ch5">
+                            <rect key="frame" x="20" y="85" width="30" height="24"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BI1-sg-udi">
+                                    <rect key="frame" x="0.0" y="0.0" width="30" height="24"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="30" id="Yia-aC-1RB"/>
+                                        <constraint firstAttribute="height" constant="24" id="wDm-G7-e25"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" name="Pretendard-Bold" family="Pretendard" pointSize="17"/>
+                                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                    <state key="normal" title="수현">
+                                        <color key="titleColor" name="white_sub"/>
+                                    </state>
+                                </button>
+                                <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dyJ-KS-VRQ">
+                                    <rect key="frame" x="0.0" y="0.0" width="30" height="24"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="24" id="bWe-5F-hfk"/>
+                                        <constraint firstAttribute="width" constant="30" id="uY5-Le-k4H"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" name="Pretendard-Bold" family="Pretendard" pointSize="17"/>
+                                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                    <state key="normal" title="수현">
+                                        <color key="titleColor" name="middle_mint_main"/>
+                                    </state>
+                                </button>
+                                <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aKM-rv-GPI">
+                                    <rect key="frame" x="0.0" y="0.0" width="30" height="24"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="24" id="cne-UI-jPg"/>
+                                        <constraint firstAttribute="width" constant="30" id="tZU-hR-4OM"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" name="Pretendard-Bold" family="Pretendard" pointSize="17"/>
+                                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                    <state key="normal" title="수현">
+                                        <color key="titleColor" name="middle_mint_main"/>
+                                    </state>
+                                </button>
+                                <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PC1-W4-Qcg">
+                                    <rect key="frame" x="0.0" y="0.0" width="30" height="24"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="24" id="Jnb-Qz-HeE"/>
+                                        <constraint firstAttribute="width" constant="30" id="gJH-nk-N50"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" name="Pretendard-Bold" family="Pretendard" pointSize="17"/>
+                                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                    <state key="normal" title="수현">
+                                        <color key="titleColor" name="middle_mint_main"/>
+                                    </state>
+                                </button>
+                                <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CDj-xa-w15">
+                                    <rect key="frame" x="0.0" y="0.0" width="30" height="24"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="30" id="UNU-di-gNv"/>
+                                        <constraint firstAttribute="height" constant="24" id="bo7-7I-SZU"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" name="Pretendard-Bold" family="Pretendard" pointSize="17"/>
+                                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                    <state key="normal" title="수현">
+                                        <color key="titleColor" name="middle_mint_main"/>
+                                    </state>
+                                </button>
+                            </subviews>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="24" id="2yB-Tn-6mM"/>
+                            </constraints>
+                        </stackView>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gfV-Yu-l7n">
+                            <rect key="frame" x="320" y="73" width="48" height="48"/>
+                            <color key="tintColor" name="white_sub"/>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" image="icPlus48"/>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" name="mint_main"/>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="AsE-uB-ch5" secondAttribute="bottom" constant="14" id="5CW-pQ-Fto"/>
+                        <constraint firstAttribute="height" constant="123" id="QGG-Vh-pNu"/>
+                        <constraint firstAttribute="trailing" secondItem="gfV-Yu-l7n" secondAttribute="trailing" constant="7" id="a1V-Ft-cWi"/>
+                        <constraint firstItem="AsE-uB-ch5" firstAttribute="leading" secondItem="lmz-WE-XjL" secondAttribute="leading" constant="20" id="qT9-UJ-e6F"/>
+                        <constraint firstItem="gfV-Yu-l7n" firstAttribute="centerY" secondItem="AsE-uB-ch5" secondAttribute="centerY" id="zuG-SG-5sn"/>
+                    </constraints>
+                </view>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="수현이이름이10글자" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W5X-qb-o7p">
+                    <rect key="frame" x="20" y="143" width="193.33333333333334" height="29"/>
+                    <fontDescription key="fontDescription" name="Pretendard-Bold" family="Pretendard" pointSize="24"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BWd-6Q-019">
+                    <rect key="frame" x="213.33333333333334" y="141.66666666666666" width="32" height="32"/>
+                    <color key="tintColor" name="gray400_sub"/>
+                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                    <state key="normal" image="icPencil32"/>
+                </button>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bcz-S9-WDa">
+                    <rect key="frame" x="0.0" y="186.66666666666666" width="375" height="124.99999999999997"/>
+                    <color key="backgroundColor" name="middle_mint_main"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="125" id="DWA-tL-cJo"/>
+                    </constraints>
+                </view>
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="mT1-S7-pLf">
+                    <rect key="frame" x="0.0" y="311.66666666666674" width="375" height="466.33333333333326"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="0xl-GJ-SDT">
+                        <size key="itemSize" width="128" height="128"/>
+                        <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                        <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                        <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                    </collectionViewFlowLayout>
+                </collectionView>
+            </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Bcz-S9-WDa" secondAttribute="trailing" id="0KH-Zp-Yla"/>
+                <constraint firstItem="W5X-qb-o7p" firstAttribute="top" secondItem="lmz-WE-XjL" secondAttribute="bottom" constant="20" id="39d-91-Jb4"/>
+                <constraint firstItem="BWd-6Q-019" firstAttribute="leading" secondItem="W5X-qb-o7p" secondAttribute="trailing" id="54C-fb-A9U"/>
+                <constraint firstItem="BWd-6Q-019" firstAttribute="centerY" secondItem="W5X-qb-o7p" secondAttribute="centerY" id="BcU-EO-I3r"/>
+                <constraint firstItem="lmz-WE-XjL" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="F0x-Jq-et3"/>
+                <constraint firstItem="Bcz-S9-WDa" firstAttribute="top" secondItem="BWd-6Q-019" secondAttribute="bottom" constant="13" id="IPs-Zv-pEj"/>
+                <constraint firstItem="Bcz-S9-WDa" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Kxg-0A-cEa"/>
+                <constraint firstItem="mT1-S7-pLf" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="XDD-aB-IXA"/>
+                <constraint firstItem="mT1-S7-pLf" firstAttribute="top" secondItem="Bcz-S9-WDa" secondAttribute="bottom" id="dyj-I4-Nmv"/>
+                <constraint firstItem="lmz-WE-XjL" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="jk4-uB-gdG"/>
+                <constraint firstItem="W5X-qb-o7p" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="lyw-62-NPL"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="mT1-S7-pLf" secondAttribute="bottom" id="uDw-Ac-Uch"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="mT1-S7-pLf" secondAttribute="trailing" id="wC4-bz-FZK"/>
+                <constraint firstItem="lmz-WE-XjL" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="wO7-kz-lJ4"/>
+            </constraints>
+            <point key="canvasLocation" x="138.40000000000001" y="146.30541871921181"/>
         </view>
     </objects>
+    <resources>
+        <image name="icPencil32" width="32" height="32"/>
+        <image name="icPlus48" width="48" height="48"/>
+        <namedColor name="gray400_sub">
+            <color red="0.76078431372549016" green="0.78823529411764703" blue="0.80784313725490198" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="middle_mint_main">
+            <color red="0.55294117647058827" green="0.92156862745098034" blue="0.90588235294117647" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="mint_main">
+            <color red="0.094117647058823528" green="0.80784313725490198" blue="0.77647058823529413" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="white_sub">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ShareViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/SobokSobok/SobokSobok/Resource/Image.xcassets/icPencil32.imageset/Contents.json
+++ b/SobokSobok/SobokSobok/Resource/Image.xcassets/icPencil32.imageset/Contents.json
@@ -1,23 +1,26 @@
 {
   "images" : [
     {
-      "scale" : "1x",
       "filename" : "icPencil32.png",
-      "idiom" : "universal"
+      "idiom" : "universal",
+      "scale" : "1x"
     },
     {
+      "filename" : "icPencil32@2x.png",
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "icPencil32@2x.png"
+      "scale" : "2x"
     },
     {
-      "scale" : "3x",
+      "filename" : "icPencil32@3x.png",
       "idiom" : "universal",
-      "filename" : "icPencil32@3x.png"
+      "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/SobokSobok/SobokSobok/Resource/Image.xcassets/icPencil48.imageset/Contents.json
+++ b/SobokSobok/SobokSobok/Resource/Image.xcassets/icPencil48.imageset/Contents.json
@@ -1,23 +1,26 @@
 {
   "images" : [
     {
+      "filename" : "icPencil48.png",
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "icPencil48.png"
+      "scale" : "1x"
     },
     {
+      "filename" : "icPencil48@2x.png",
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "icPencil48@2x.png"
+      "scale" : "2x"
     },
     {
-      "idiom" : "universal",
       "filename" : "icPencil48@3x.png",
+      "idiom" : "universal",
       "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/SobokSobok/SobokSobok/Resource/Image.xcassets/icPlus48.imageset/Contents.json
+++ b/SobokSobok/SobokSobok/Resource/Image.xcassets/icPlus48.imageset/Contents.json
@@ -1,23 +1,26 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
       "filename" : "icPlus48.png",
+      "idiom" : "universal",
       "scale" : "1x"
     },
     {
       "filename" : "icPlus48@2x.png",
-      "scale" : "2x",
-      "idiom" : "universal"
+      "idiom" : "universal",
+      "scale" : "2x"
     },
     {
-      "scale" : "3x",
+      "filename" : "icPlus48@3x.png",
       "idiom" : "universal",
-      "filename" : "icPlus48@3x.png"
+      "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->

공유탭의 루트 뷰컨트롤러의 UI 영역을 잡았습니다.
재사용 뷰로 빼는 작업과 디테일 작업은 다른 이슈에서 진행합니다.

🌱 작업한 브랜치

- feature/#31

🌱 작업한 내용

- ShareViewController.swift, xib 파일 생성
- 공유탭 UI 영역 구현

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | ![Simulator Screen Recording - iPhone 13 mini - 2022-01-12 at 17 26 36](https://user-images.githubusercontent.com/61109660/149090991-f85a0a6a-cf4f-437f-aca4-b6db64f54727.gif)|

## 📮 관련 이슈

- Resolved: #31 