### PR TITLE
[#38, #39] 회원가입 기능 구현

### DIFF
--- a/SobokSobok/SobokSobok/Application/AppDelegate.swift
+++ b/SobokSobok/SobokSobok/Application/AppDelegate.swift
@@ -6,14 +6,16 @@
 //
 
 import UIKit
+import IQKeyboardManagerSwift
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
+    
+    var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        IQKeyboardManager.shared.enable = true
         return true
     }
 

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -48,11 +48,13 @@ final class SignUpViewController: BaseViewController {
     
     // MARK: Functions
     
+    // 비밀번호 숨기기
     private func securePassword() {
         passwordTextField.isSecureTextEntry = true
         rePasswordTextField.isSecureTextEntry = true
     }
     
+    // 텍스트필드 addTarget
     private func checkTextField() {
         emailWarningStackView.isHidden = true
         emailTextField.addTarget(self, action: #selector(self.checkEmailTextField), for: .editingChanged)
@@ -60,25 +62,27 @@ final class SignUpViewController: BaseViewController {
         rePasswordTextField.addTarget(self, action: #selector(self.checkRepasswordTextField), for: .editingChanged)
     }
     
-    @objc private func checkEmailTextField() {
-        emailRight = checkEmailRight(input: emailTextField.text ?? "")
-        emailWarningStackView.isHidden = emailRight || !emailTextField.hasText ? true : false
-    }
-    
+    // 정규식 체크
     private func checkEmailRight (input: String) -> Bool {
         // 이메일 조건 : [대문자,소문자,숫자,특수기호] + 골뱅이(@) + [대문자,소문자,숫자,.,-] + 점(.) + [대문자,소문자]
         let validEmail = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
         let emailTest = NSPredicate(format: "SELF MATCHES %@", validEmail)
           return emailTest.evaluate(with: input)
     }
-    
-    @objc private func checkPasswordTextField() {
-        
+    private func checkPasswordRight (input: String) -> Bool {
+        // 이메일 조건 : [대문자,소문자,숫자,특수기호] + 골뱅이(@) + [대문자,소문자,숫자,.,-] + 점(.) + [대문자,소문자]
+        let validEmail = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+        let emailTest = NSPredicate(format: "SELF MATCHES %@", validEmail)
+          return emailTest.evaluate(with: input)
+    }
+    private func checkRepasswordRight (input: String) -> Bool {
+        // 이메일 조건 : [대문자,소문자,숫자,특수기호] + 골뱅이(@) + [대문자,소문자,숫자,.,-] + 점(.) + [대문자,소문자]
+        let validEmail = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+        let emailTest = NSPredicate(format: "SELF MATCHES %@", validEmail)
+          return emailTest.evaluate(with: input)
     }
     
-    @objc private func checkRepasswordTextField() {
-        
-    }
+    
 
     // Alert
     func tempAlert(title: String, message: String) {
@@ -88,10 +92,26 @@ final class SignUpViewController: BaseViewController {
         present(alert, animated: true)
     }
     
+    // 조건에 따른 경고문구 숨김여부 결정
+    @objc private func checkEmailTextField() {
+        emailRight = checkEmailRight(input: emailTextField.text ?? "")
+        emailWarningStackView.isHidden = emailRight || !emailTextField.hasText ? true : false
+    }
+    
+    @objc private func checkPasswordTextField() {
+        
+    }
+    
+    @objc private func checkRepasswordTextField() {
+        
+    }
+    
+    // 버튼 활성화
     @objc func activateOkayButton(_ : UIButton) {
         okayButton.isEnabled = emailRight && passwordRight && rePasswordRight ? true : false
     }
     
+    // 회원가입 버튼 클릭
     @IBAction func touchUpToSignUp(_ sender: UIButton) {
         if passwordTextField.text == rePasswordTextField.text {
             tempAlert(title: "회원가입", message: "이메일 : \(emailTextField.text ?? ""), 비밀번호 : \(passwordTextField.text ?? "")")

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -13,10 +13,8 @@ final class SignUpViewController: BaseViewController {
     var emailRight: Bool = false
     var passwordRight: Bool = false
     var rePasswordRight: Bool = false
-    var totalViewPosition: CGFloat = 0
     
     // MARK: @IBOutlet Properties
-    
     @IBOutlet weak var totalView: UIView!
     @IBOutlet weak var okayButton: UIButton!
     // 텍스트필드
@@ -36,37 +34,6 @@ final class SignUpViewController: BaseViewController {
         super.viewDidLoad()
         setUI()
         checkTextField()
-        addKeyboardNotification()
-    }
-    
-    private func addKeyboardNotification() {
-        totalViewPosition = totalView.frame.origin.y
-
-        NotificationCenter.default.addObserver(
-          self,
-          selector: #selector(keyboardWillShow),
-          name: UIResponder.keyboardWillShowNotification,
-          object: nil
-        )
-        
-        NotificationCenter.default.addObserver(
-          self,
-          selector: #selector(keyboardWillHide),
-          name: UIResponder.keyboardWillHideNotification,
-          object: nil
-        )
-      }
-    
-    @objc private func keyboardWillShow(_ notification: Notification) {
-      if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
-          self.totalView.frame.origin.y = totalViewPosition - 70
-      }
-    }
-      
-    @objc private func keyboardWillHide(_ notification: Notification) {
-      if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
-          self.totalView.frame.origin.y = totalViewPosition + 22
-      }
     }
     
     // MARK: Functions

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -13,8 +13,11 @@ final class SignUpViewController: BaseViewController {
     var emailRight: Bool = false
     var passwordRight: Bool = false
     var rePasswordRight: Bool = false
+    var totalViewPosition: CGFloat = 0
     
     // MARK: @IBOutlet Properties
+    
+    @IBOutlet weak var totalView: UIView!
     @IBOutlet weak var okayButton: UIButton!
     // 텍스트필드
     @IBOutlet weak var emailTextField: UITextField!
@@ -33,6 +36,37 @@ final class SignUpViewController: BaseViewController {
         super.viewDidLoad()
         setUI()
         checkTextField()
+        addKeyboardNotification()
+    }
+    
+    private func addKeyboardNotification() {
+        totalViewPosition = totalView.frame.origin.y
+
+        NotificationCenter.default.addObserver(
+          self,
+          selector: #selector(keyboardWillShow),
+          name: UIResponder.keyboardWillShowNotification,
+          object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+          self,
+          selector: #selector(keyboardWillHide),
+          name: UIResponder.keyboardWillHideNotification,
+          object: nil
+        )
+      }
+    
+    @objc private func keyboardWillShow(_ notification: Notification) {
+      if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+          self.totalView.frame.origin.y = totalViewPosition - 70
+      }
+    }
+      
+    @objc private func keyboardWillHide(_ notification: Notification) {
+      if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+          self.totalView.frame.origin.y = totalViewPosition + 22
+      }
     }
     
     // MARK: Functions

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -38,9 +38,7 @@ final class SignUpViewController: BaseViewController {
     
     // MARK: Functions
     private func setUI() {
-        emailTextFieldView.makeRoundedWithBorder(radius: 12, color: Color.gray300.cgColor)
-        passwordTextFieldView.makeRoundedWithBorder(radius: 12, color: Color.gray300.cgColor)
-        rePasswordTextFieldView.makeRoundedWithBorder(radius: 12, color: Color.gray300.cgColor)
+        [emailTextFieldView, passwordTextFieldView, rePasswordTextFieldView].forEach {$0.makeRoundedWithBorder(radius: 12, color: Color.gray300.cgColor)}
     }
     
     private func securePassword() {

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -103,11 +103,13 @@ final class SignUpViewController: BaseViewController {
     @objc private func checkEmailTextField() {
         emailRight = checkEmailRight(input: emailTextField.text ?? "")
         emailWarningStackView.isHidden = emailRight || !emailTextField.hasText ? true : false
+        emailTextFieldView.layer.borderColor = emailRight || !emailTextField.hasText ? Color.gray300.cgColor : Color.pillColorRed.cgColor
     }
     
     @objc private func checkPasswordTextField() {
         passwordRight = checkPasswordRight(input: passwordTextField.text ?? "")
         passwordWarningStackView.isHidden = passwordRight || !passwordTextField.hasText ? true : false
+        passwordTextFieldView.layer.borderColor = emailRight || !emailTextField.hasText ? Color.gray300.cgColor : Color.pillColorRed.cgColor
     }
     
     @objc private func checkRepasswordTextField() {

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -61,11 +61,19 @@ final class SignUpViewController: BaseViewController {
     }
     
     @objc private func checkEmailTextField() {
+        emailRight = checkEmailRight(input: emailTextField.text ?? "")
         if emailRight || !emailTextField.hasText {
             emailWarningStackView.isHidden = true
         } else {
             emailWarningStackView.isHidden = false
         }
+    }
+    
+    private func checkEmailRight (input: String) -> Bool {
+        // 이메일 조건 : [대문자,소문자,숫자,특수기호] + 골뱅이(@) + [대문자,소문자,숫자,.,-] + 점(.) + [대문자,소문자]
+        let validEmail = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+        let emailTest = NSPredicate(format: "SELF MATCHES %@", validEmail)
+          return emailTest.evaluate(with: input)
     }
     
     @objc private func checkPasswordTextField() {

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -62,11 +62,7 @@ final class SignUpViewController: BaseViewController {
     
     @objc private func checkEmailTextField() {
         emailRight = checkEmailRight(input: emailTextField.text ?? "")
-        if emailRight || !emailTextField.hasText {
-            emailWarningStackView.isHidden = true
-        } else {
-            emailWarningStackView.isHidden = false
-        }
+        emailWarningStackView.isHidden = emailRight || !emailTextField.hasText ? true : false
     }
     
     private func checkEmailRight (input: String) -> Bool {

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -66,29 +66,28 @@ final class SignUpViewController: BaseViewController {
     private func checkTextField() {
         emailTextField.addTarget(self, action: #selector(self.checkEmailTextField), for: .editingChanged)
         passwordTextField.addTarget(self, action: #selector(self.checkPasswordTextField), for: .editingChanged)
+        passwordTextField.addTarget(self, action: #selector(self.checkRepasswordTextField), for: .editingChanged)
         rePasswordTextField.addTarget(self, action: #selector(self.checkRepasswordTextField), for: .editingChanged)
     }
     
     // 정규식 체크
     private func checkEmailRight (input: String) -> Bool {
-        // 이메일 조건 : [대문자,소문자,숫자,특수기호] + 골뱅이(@) + [대문자,소문자,숫자,.,-] + 점(.) + [대문자,소문자]
+        // 이메일 조건 : [대문자,소문자,숫자,특수기호] + 골뱅이(@) + [대문자,소문자,숫자,.,-] + 점(.) + [대문자,소문자] 2~64글자
         let validEmail = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
         let emailTest = NSPredicate(format: "SELF MATCHES %@", validEmail)
           return emailTest.evaluate(with: input)
     }
     
     private func checkPasswordRight (input: String) -> Bool {
-        // 이메일 조건 : [대문자,소문자,숫자,특수기호] + 골뱅이(@) + [대문자,소문자,숫자,.,-] + 점(.) + [대문자,소문자]
+        // 비밀번호 조건 : [대문자,소문자,숫자,특수기호] 8~16글자
         let validPassword = "[A-Z0-9a-z!@#$%^&*()_+=-]{8,16}"
         let passwordTest = NSPredicate(format: "SELF MATCHES %@", validPassword)
           return passwordTest.evaluate(with: input)
     }
     
     private func checkRepasswordRight (input: String) -> Bool {
-        // 이메일 조건 : [대문자,소문자,숫자,특수기호] + 골뱅이(@) + [대문자,소문자,숫자,.,-] + 점(.) + [대문자,소문자]
-        let validEmail = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
-        let emailTest = NSPredicate(format: "SELF MATCHES %@", validEmail)
-          return emailTest.evaluate(with: input)
+        // 비밀번호 재입력 조건 : 비밀번호와 값이 같아야함
+        return passwordTextField.text == rePasswordTextField.text ? true : false
     }
 
     // Alert
@@ -109,11 +108,13 @@ final class SignUpViewController: BaseViewController {
     @objc private func checkPasswordTextField() {
         passwordRight = checkPasswordRight(input: passwordTextField.text ?? "")
         passwordWarningStackView.isHidden = passwordRight || !passwordTextField.hasText ? true : false
-        passwordTextFieldView.layer.borderColor = emailRight || !emailTextField.hasText ? Color.gray300.cgColor : Color.pillColorRed.cgColor
+        passwordTextFieldView.layer.borderColor = passwordRight || !passwordTextField.hasText ? Color.gray300.cgColor : Color.pillColorRed.cgColor
     }
     
     @objc private func checkRepasswordTextField() {
-        
+        rePasswordRight = checkRepasswordRight(input: passwordTextField.text ?? "")
+        rePasswordWarningStackView.isHidden = rePasswordRight || !rePasswordTextField.hasText ? true : false
+        rePasswordTextFieldView.layer.borderColor = rePasswordRight || !rePasswordTextField.hasText ? Color.gray300.cgColor : Color.pillColorRed.cgColor
     }
     
     // 버튼 활성화

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -66,8 +66,8 @@ final class SignUpViewController: BaseViewController {
     private func checkTextField() {
         emailTextField.addTarget(self, action: #selector(self.checkEmailTextField), for: .editingChanged)
         passwordTextField.addTarget(self, action: #selector(self.checkPasswordTextField), for: .editingChanged)
-        passwordTextField.addTarget(self, action: #selector(self.checkRepasswordTextField), for: .editingChanged)
-        rePasswordTextField.addTarget(self, action: #selector(self.checkRepasswordTextField), for: .editingChanged)
+        [passwordTextField, rePasswordTextField].forEach {$0.addTarget(self, action: #selector(self.checkRepasswordTextField), for: .editingChanged)}
+        [emailTextField, passwordTextField, rePasswordTextField].forEach {$0.addTarget(self, action: #selector(self.activateOkayButton(_:)), for: .editingChanged)}
     }
     
     // 정규식 체크

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -37,13 +37,17 @@ final class SignUpViewController: BaseViewController {
     }
     
     override func style() {
-        // 텍스트필드 corner radius 처리 눈속임
+        // corner radius (텍스트필드, 버튼)
         [emailTextFieldView, passwordTextFieldView, rePasswordTextFieldView].forEach {$0.makeRoundedWithBorder(radius: 12, color: Color.gray300.cgColor)}
+        okayButton.makeRounded(radius: 12)
         
-        // 경고문구는 처음에 사라지게 만들기
+        // 초기세팅 : 경고문구 사라지게 만들기
         emailWarningStackView.isHidden = true
         passwordWarningStackView.isHidden = true
         rePasswordWarningStackView.isHidden = true
+        
+        // 초기세팅 : 버튼비활성화
+        okayButton.isEnabled = false
         
         // 네비게이션 바 커스텀
         title = "회원가입"

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -30,12 +30,20 @@ final class SignUpViewController: BaseViewController {
     @IBOutlet weak var rePasswordWarningStackView: UIStackView!
     
     // MARK: View Life Cycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         checkTextField()
     }
+    
     override func style() {
+        // 텍스트필드 corner radius 처리 눈속임
         [emailTextFieldView, passwordTextFieldView, rePasswordTextFieldView].forEach {$0.makeRoundedWithBorder(radius: 12, color: Color.gray300.cgColor)}
+        
+        // 경고문구는 처음에 사라지게 만들기
+        emailWarningStackView.isHidden = true
+        passwordWarningStackView.isHidden = true
+        rePasswordWarningStackView.isHidden = true
         
         // 네비게이션 바 커스텀
         title = "회원가입"
@@ -56,7 +64,6 @@ final class SignUpViewController: BaseViewController {
     
     // 텍스트필드 addTarget
     private func checkTextField() {
-        emailWarningStackView.isHidden = true
         emailTextField.addTarget(self, action: #selector(self.checkEmailTextField), for: .editingChanged)
         passwordTextField.addTarget(self, action: #selector(self.checkPasswordTextField), for: .editingChanged)
         rePasswordTextField.addTarget(self, action: #selector(self.checkRepasswordTextField), for: .editingChanged)
@@ -69,20 +76,20 @@ final class SignUpViewController: BaseViewController {
         let emailTest = NSPredicate(format: "SELF MATCHES %@", validEmail)
           return emailTest.evaluate(with: input)
     }
+    
     private func checkPasswordRight (input: String) -> Bool {
         // 이메일 조건 : [대문자,소문자,숫자,특수기호] + 골뱅이(@) + [대문자,소문자,숫자,.,-] + 점(.) + [대문자,소문자]
-        let validEmail = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
-        let emailTest = NSPredicate(format: "SELF MATCHES %@", validEmail)
-          return emailTest.evaluate(with: input)
+        let validPassword = "[A-Z0-9a-z!@#$%^&*()_+=-]{8,16}"
+        let passwordTest = NSPredicate(format: "SELF MATCHES %@", validPassword)
+          return passwordTest.evaluate(with: input)
     }
+    
     private func checkRepasswordRight (input: String) -> Bool {
         // 이메일 조건 : [대문자,소문자,숫자,특수기호] + 골뱅이(@) + [대문자,소문자,숫자,.,-] + 점(.) + [대문자,소문자]
         let validEmail = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
         let emailTest = NSPredicate(format: "SELF MATCHES %@", validEmail)
           return emailTest.evaluate(with: input)
     }
-    
-    
 
     // Alert
     func tempAlert(title: String, message: String) {
@@ -99,7 +106,8 @@ final class SignUpViewController: BaseViewController {
     }
     
     @objc private func checkPasswordTextField() {
-        
+        passwordRight = checkPasswordRight(input: passwordTextField.text ?? "")
+        passwordWarningStackView.isHidden = passwordRight || !passwordTextField.hasText ? true : false
     }
     
     @objc private func checkRepasswordTextField() {

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -32,14 +32,21 @@ final class SignUpViewController: BaseViewController {
     // MARK: View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        setUI()
         checkTextField()
+    }
+    override func style() {
+        [emailTextFieldView, passwordTextFieldView, rePasswordTextFieldView].forEach {$0.makeRoundedWithBorder(radius: 12, color: Color.gray300.cgColor)}
+        
+        // 네비게이션 바 커스텀
+        title = "회원가입"
+        let backButton = UIBarButtonItem()
+        self.navigationController?.navigationBar.topItem?.backBarButtonItem = backButton
+        backButton.title = ""
+        backButton.tintColor = .black
+        self.navigationController?.navigationBar.backgroundColor = .white
     }
     
     // MARK: Functions
-    private func setUI() {
-        [emailTextFieldView, passwordTextFieldView, rePasswordTextFieldView].forEach {$0.makeRoundedWithBorder(radius: 12, color: Color.gray300.cgColor)}
-    }
     
     private func securePassword() {
         passwordTextField.isSecureTextEntry = true

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.xib
@@ -51,7 +51,7 @@
                     </connections>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1eY-fr-ddQ" userLabel="뷰">
-                    <rect key="frame" x="0.0" y="44" width="414" height="495"/>
+                    <rect key="frame" x="0.0" y="110" width="414" height="495"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가입하실 이메일과 비밀번호를 입력해주세요" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dgS-YB-bvH">
                             <rect key="frame" x="20" y="22" width="374" height="55"/>
@@ -234,13 +234,14 @@
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="1eY-fr-ddQ" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="HrE-YV-Ldt"/>
+                <constraint firstItem="1eY-fr-ddQ" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="22" id="93e-qf-2L0"/>
                 <constraint firstItem="3jM-k7-QOd" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="kLg-b2-pPt"/>
                 <constraint firstItem="1eY-fr-ddQ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="mV6-D2-cCC"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="3jM-k7-QOd" secondAttribute="bottom" constant="22" id="r6Y-QA-y6K"/>
                 <constraint firstItem="1eY-fr-ddQ" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="sK3-r1-f6Y"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="3jM-k7-QOd" secondAttribute="trailing" constant="20" id="vrd-VZ-Msm"/>
             </constraints>
+            <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
             <point key="canvasLocation" x="131.8840579710145" y="90.401785714285708"/>
         </view>
     </objects>

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.xib
@@ -22,6 +22,7 @@
                 <outlet property="rePasswordTextField" destination="fO5-Vf-KYD" id="5Rf-u1-tHh"/>
                 <outlet property="rePasswordTextFieldView" destination="Dcb-J4-rZh" id="lv2-eB-dYV"/>
                 <outlet property="rePasswordWarningStackView" destination="2ez-ye-BIa" id="JBY-qC-RbD"/>
+                <outlet property="totalView" destination="1eY-fr-ddQ" id="CXV-hw-dfm"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -30,165 +31,6 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가입하실 이메일과 비밀번호를 입력해주세요" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dgS-YB-bvH">
-                    <rect key="frame" x="20" y="66" width="374" height="55"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="23"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cZc-Nb-vxf" userLabel="이메일 스택">
-                    <rect key="frame" x="20" y="165" width="374" height="106"/>
-                    <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이메일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2fa-uJ-6ls">
-                            <rect key="frame" x="0.0" y="0.0" width="39" height="18"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iaH-VC-WqO" userLabel="이메일텍스트필드">
-                            <rect key="frame" x="0.0" y="26" width="374" height="54"/>
-                            <subviews>
-                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="soboksobok@gmail.com" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Bdf-4X-ikb" userLabel="이메일">
-                                    <rect key="frame" x="15" y="15" width="344" height="24"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                    <textInputTraits key="textInputTraits"/>
-                                </textField>
-                            </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                            <constraints>
-                                <constraint firstAttribute="bottom" secondItem="Bdf-4X-ikb" secondAttribute="bottom" constant="15" id="CBz-LX-Afa"/>
-                                <constraint firstAttribute="height" constant="54" id="UO2-7t-1DF"/>
-                                <constraint firstAttribute="trailing" secondItem="Bdf-4X-ikb" secondAttribute="trailing" constant="15" id="ajW-Hy-Ogo"/>
-                                <constraint firstItem="Bdf-4X-ikb" firstAttribute="leading" secondItem="iaH-VC-WqO" secondAttribute="leading" constant="15" id="h1n-7T-iA4"/>
-                                <constraint firstItem="Bdf-4X-ikb" firstAttribute="top" secondItem="iaH-VC-WqO" secondAttribute="top" constant="15" id="nHN-b2-qxY"/>
-                            </constraints>
-                        </view>
-                        <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="itb-y6-TcY" userLabel="이메일 형식이 올바르지 않아요">
-                            <rect key="frame" x="0.0" y="88" width="167" height="18"/>
-                            <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wvl-vc-6wj">
-                                    <rect key="frame" x="0.0" y="0.0" width="10" height="18"/>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="10" id="Ucp-tl-ixb"/>
-                                        <constraint firstAttribute="height" constant="18" id="Y63-Vq-1f9"/>
-                                    </constraints>
-                                </view>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이메일 형식이 올바르지 않아요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ejO-1n-ptE">
-                                    <rect key="frame" x="10" y="0.0" width="157" height="16"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                    <color key="textColor" name="pill_color_red"/>
-                                    <color key="highlightedColor" name="black_sub"/>
-                                </label>
-                            </subviews>
-                        </stackView>
-                    </subviews>
-                    <constraints>
-                        <constraint firstItem="iaH-VC-WqO" firstAttribute="centerX" secondItem="cZc-Nb-vxf" secondAttribute="centerX" id="N8H-kG-qfR"/>
-                    </constraints>
-                </stackView>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ljr-Y9-NfJ" userLabel="비밀번호 스택">
-                    <rect key="frame" x="20" y="299" width="374" height="106"/>
-                    <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="비밀번호" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AM7-lP-LjL">
-                            <rect key="frame" x="0.0" y="0.0" width="52" height="18"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8wN-5t-vpk" userLabel="비밀번호텍스트필드">
-                            <rect key="frame" x="0.0" y="26" width="374" height="54"/>
-                            <subviews>
-                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="8~16자의 영문, 숫자, 특수문자" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LU6-Xm-bpc" userLabel="비밀번호">
-                                    <rect key="frame" x="15" y="15" width="344" height="24"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                    <textInputTraits key="textInputTraits"/>
-                                </textField>
-                            </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="54" id="2sx-9O-h0A"/>
-                                <constraint firstItem="LU6-Xm-bpc" firstAttribute="leading" secondItem="8wN-5t-vpk" secondAttribute="leading" constant="15" id="6w1-hq-x2y"/>
-                                <constraint firstAttribute="trailing" secondItem="LU6-Xm-bpc" secondAttribute="trailing" constant="15" id="Zuh-dN-ywv"/>
-                                <constraint firstItem="LU6-Xm-bpc" firstAttribute="top" secondItem="8wN-5t-vpk" secondAttribute="top" constant="15" id="h7E-ih-hAH"/>
-                                <constraint firstAttribute="bottom" secondItem="LU6-Xm-bpc" secondAttribute="bottom" constant="15" id="yGd-QF-Tln"/>
-                            </constraints>
-                        </view>
-                        <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="Ydh-UF-cgO" userLabel="비밀번호형식은어쩌구">
-                            <rect key="frame" x="0.0" y="88" width="268.5" height="18"/>
-                            <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SMR-9y-tVj">
-                                    <rect key="frame" x="0.0" y="0.0" width="10" height="18"/>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="18" id="4gR-R2-crY"/>
-                                        <constraint firstAttribute="width" constant="10" id="f0d-vA-4sS"/>
-                                    </constraints>
-                                </view>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8~16자리의 영문, 숫자, 특수문자만 사용 가능해요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FId-4b-I2F" userLabel="비밀번호형식은어쩌구">
-                                    <rect key="frame" x="10" y="0.0" width="258.5" height="16"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                    <color key="textColor" name="pill_color_red"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                            </subviews>
-                        </stackView>
-                    </subviews>
-                    <constraints>
-                        <constraint firstItem="8wN-5t-vpk" firstAttribute="centerX" secondItem="ljr-Y9-NfJ" secondAttribute="centerX" id="ASm-gh-42Z"/>
-                    </constraints>
-                </stackView>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="KeA-dZ-aEK" userLabel="비밀번호 재입력 스택">
-                    <rect key="frame" x="20" y="433" width="374" height="106"/>
-                    <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="비밀번호 재입력" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ghb-8j-XvT">
-                            <rect key="frame" x="0.0" y="0.0" width="95" height="18"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dcb-J4-rZh" userLabel="비밀번호재입력 텍스트필드">
-                            <rect key="frame" x="0.0" y="26" width="374" height="54"/>
-                            <subviews>
-                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="비밀번호를 한번 더 입력해 주세요" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fO5-Vf-KYD" userLabel="비밀번호 재입력">
-                                    <rect key="frame" x="15" y="15" width="344" height="24"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                    <textInputTraits key="textInputTraits"/>
-                                </textField>
-                            </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                            <constraints>
-                                <constraint firstAttribute="bottom" secondItem="fO5-Vf-KYD" secondAttribute="bottom" constant="15" id="Nsv-YZ-o3n"/>
-                                <constraint firstAttribute="trailing" secondItem="fO5-Vf-KYD" secondAttribute="trailing" constant="15" id="dHi-Wy-LFd"/>
-                                <constraint firstAttribute="height" constant="54" id="eN2-Pb-vH7"/>
-                                <constraint firstItem="fO5-Vf-KYD" firstAttribute="top" secondItem="Dcb-J4-rZh" secondAttribute="top" constant="15" id="uOM-f5-flE"/>
-                                <constraint firstItem="fO5-Vf-KYD" firstAttribute="leading" secondItem="Dcb-J4-rZh" secondAttribute="leading" constant="15" id="zjd-sC-S8e"/>
-                            </constraints>
-                        </view>
-                        <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="2ez-ye-BIa" userLabel="비밀번호가 일치하지 않아요">
-                            <rect key="frame" x="0.0" y="88" width="152.5" height="18"/>
-                            <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4B5-U1-z4f">
-                                    <rect key="frame" x="0.0" y="0.0" width="10" height="18"/>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="10" id="Jhl-8a-Hyr"/>
-                                        <constraint firstAttribute="height" constant="18" id="TYx-6c-yz9"/>
-                                    </constraints>
-                                </view>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="비밀번호가 일치하지 않아요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iID-Dt-Gg1">
-                                    <rect key="frame" x="10" y="0.0" width="142.5" height="16"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                    <color key="textColor" name="pill_color_red"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                            </subviews>
-                        </stackView>
-                    </subviews>
-                    <constraints>
-                        <constraint firstItem="Dcb-J4-rZh" firstAttribute="centerX" secondItem="KeA-dZ-aEK" secondAttribute="centerX" id="e91-IP-cTu"/>
-                    </constraints>
-                </stackView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3jM-k7-QOd">
                     <rect key="frame" x="20" y="788" width="374" height="52"/>
                     <constraints>
@@ -208,27 +50,198 @@
                         <action selector="touchUpToSignUp:" destination="-1" eventType="touchUpInside" id="O6s-45-nay"/>
                     </connections>
                 </button>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1eY-fr-ddQ" userLabel="뷰">
+                    <rect key="frame" x="0.0" y="44" width="414" height="495"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가입하실 이메일과 비밀번호를 입력해주세요" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dgS-YB-bvH">
+                            <rect key="frame" x="20" y="22" width="374" height="55"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="23"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ljr-Y9-NfJ" userLabel="비밀번호 스택">
+                            <rect key="frame" x="20" y="255" width="374" height="106"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="비밀번호" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AM7-lP-LjL">
+                                    <rect key="frame" x="0.0" y="0.0" width="52" height="18"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8wN-5t-vpk" userLabel="비밀번호텍스트필드">
+                                    <rect key="frame" x="0.0" y="26" width="374" height="54"/>
+                                    <subviews>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="8~16자의 영문, 숫자, 특수문자" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LU6-Xm-bpc" userLabel="비밀번호">
+                                            <rect key="frame" x="15" y="15" width="344" height="24"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="54" id="2sx-9O-h0A"/>
+                                        <constraint firstItem="LU6-Xm-bpc" firstAttribute="leading" secondItem="8wN-5t-vpk" secondAttribute="leading" constant="15" id="6w1-hq-x2y"/>
+                                        <constraint firstAttribute="trailing" secondItem="LU6-Xm-bpc" secondAttribute="trailing" constant="15" id="Zuh-dN-ywv"/>
+                                        <constraint firstItem="LU6-Xm-bpc" firstAttribute="top" secondItem="8wN-5t-vpk" secondAttribute="top" constant="15" id="h7E-ih-hAH"/>
+                                        <constraint firstAttribute="bottom" secondItem="LU6-Xm-bpc" secondAttribute="bottom" constant="15" id="yGd-QF-Tln"/>
+                                    </constraints>
+                                </view>
+                                <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="Ydh-UF-cgO" userLabel="비밀번호형식은어쩌구">
+                                    <rect key="frame" x="0.0" y="88" width="268.5" height="18"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SMR-9y-tVj">
+                                            <rect key="frame" x="0.0" y="0.0" width="10" height="18"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="18" id="4gR-R2-crY"/>
+                                                <constraint firstAttribute="width" constant="10" id="f0d-vA-4sS"/>
+                                            </constraints>
+                                        </view>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8~16자리의 영문, 숫자, 특수문자만 사용 가능해요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FId-4b-I2F" userLabel="비밀번호형식은어쩌구">
+                                            <rect key="frame" x="10" y="0.0" width="258.5" height="16"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                            <color key="textColor" name="pill_color_red"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="8wN-5t-vpk" firstAttribute="centerX" secondItem="ljr-Y9-NfJ" secondAttribute="centerX" id="ASm-gh-42Z"/>
+                            </constraints>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="KeA-dZ-aEK" userLabel="비밀번호 재입력 스택">
+                            <rect key="frame" x="20" y="389" width="374" height="106"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="비밀번호 재입력" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ghb-8j-XvT">
+                                    <rect key="frame" x="0.0" y="0.0" width="95" height="18"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dcb-J4-rZh" userLabel="비밀번호재입력 텍스트필드">
+                                    <rect key="frame" x="0.0" y="26" width="374" height="54"/>
+                                    <subviews>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="비밀번호를 한번 더 입력해 주세요" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fO5-Vf-KYD" userLabel="비밀번호 재입력">
+                                            <rect key="frame" x="15" y="15" width="344" height="24"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="fO5-Vf-KYD" secondAttribute="bottom" constant="15" id="Nsv-YZ-o3n"/>
+                                        <constraint firstAttribute="trailing" secondItem="fO5-Vf-KYD" secondAttribute="trailing" constant="15" id="dHi-Wy-LFd"/>
+                                        <constraint firstAttribute="height" constant="54" id="eN2-Pb-vH7"/>
+                                        <constraint firstItem="fO5-Vf-KYD" firstAttribute="top" secondItem="Dcb-J4-rZh" secondAttribute="top" constant="15" id="uOM-f5-flE"/>
+                                        <constraint firstItem="fO5-Vf-KYD" firstAttribute="leading" secondItem="Dcb-J4-rZh" secondAttribute="leading" constant="15" id="zjd-sC-S8e"/>
+                                    </constraints>
+                                </view>
+                                <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="2ez-ye-BIa" userLabel="비밀번호가 일치하지 않아요">
+                                    <rect key="frame" x="0.0" y="88" width="152.5" height="18"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4B5-U1-z4f">
+                                            <rect key="frame" x="0.0" y="0.0" width="10" height="18"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="10" id="Jhl-8a-Hyr"/>
+                                                <constraint firstAttribute="height" constant="18" id="TYx-6c-yz9"/>
+                                            </constraints>
+                                        </view>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="비밀번호가 일치하지 않아요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iID-Dt-Gg1">
+                                            <rect key="frame" x="10" y="0.0" width="142.5" height="16"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                            <color key="textColor" name="pill_color_red"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="Dcb-J4-rZh" firstAttribute="centerX" secondItem="KeA-dZ-aEK" secondAttribute="centerX" id="e91-IP-cTu"/>
+                            </constraints>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cZc-Nb-vxf" userLabel="이메일 스택">
+                            <rect key="frame" x="20" y="121" width="374" height="106"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이메일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2fa-uJ-6ls">
+                                    <rect key="frame" x="0.0" y="0.0" width="39" height="18"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iaH-VC-WqO" userLabel="이메일텍스트필드">
+                                    <rect key="frame" x="0.0" y="26" width="374" height="54"/>
+                                    <subviews>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="soboksobok@gmail.com" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Bdf-4X-ikb" userLabel="이메일">
+                                            <rect key="frame" x="15" y="15" width="344" height="24"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="Bdf-4X-ikb" secondAttribute="bottom" constant="15" id="CBz-LX-Afa"/>
+                                        <constraint firstAttribute="height" constant="54" id="UO2-7t-1DF"/>
+                                        <constraint firstAttribute="trailing" secondItem="Bdf-4X-ikb" secondAttribute="trailing" constant="15" id="ajW-Hy-Ogo"/>
+                                        <constraint firstItem="Bdf-4X-ikb" firstAttribute="leading" secondItem="iaH-VC-WqO" secondAttribute="leading" constant="15" id="h1n-7T-iA4"/>
+                                        <constraint firstItem="Bdf-4X-ikb" firstAttribute="top" secondItem="iaH-VC-WqO" secondAttribute="top" constant="15" id="nHN-b2-qxY"/>
+                                    </constraints>
+                                </view>
+                                <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="itb-y6-TcY" userLabel="이메일 형식이 올바르지 않아요">
+                                    <rect key="frame" x="0.0" y="88" width="167" height="18"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wvl-vc-6wj">
+                                            <rect key="frame" x="0.0" y="0.0" width="10" height="18"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="10" id="Ucp-tl-ixb"/>
+                                                <constraint firstAttribute="height" constant="18" id="Y63-Vq-1f9"/>
+                                            </constraints>
+                                        </view>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이메일 형식이 올바르지 않아요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ejO-1n-ptE">
+                                            <rect key="frame" x="10" y="0.0" width="157" height="16"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                            <color key="textColor" name="pill_color_red"/>
+                                            <color key="highlightedColor" name="black_sub"/>
+                                        </label>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="iaH-VC-WqO" firstAttribute="centerX" secondItem="cZc-Nb-vxf" secondAttribute="centerX" id="N8H-kG-qfR"/>
+                            </constraints>
+                        </stackView>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="cZc-Nb-vxf" secondAttribute="trailing" constant="20" id="0Yj-2l-xAn"/>
+                        <constraint firstItem="KeA-dZ-aEK" firstAttribute="leading" secondItem="1eY-fr-ddQ" secondAttribute="leading" constant="20" id="11o-zy-ufU"/>
+                        <constraint firstItem="dgS-YB-bvH" firstAttribute="leading" secondItem="1eY-fr-ddQ" secondAttribute="leading" constant="20" id="2NV-lr-dZj"/>
+                        <constraint firstItem="dgS-YB-bvH" firstAttribute="top" secondItem="1eY-fr-ddQ" secondAttribute="top" constant="22" id="Jvs-uk-aNC"/>
+                        <constraint firstItem="KeA-dZ-aEK" firstAttribute="top" secondItem="ljr-Y9-NfJ" secondAttribute="bottom" constant="28" id="Lxj-rg-aVf"/>
+                        <constraint firstAttribute="trailing" secondItem="KeA-dZ-aEK" secondAttribute="trailing" constant="20" id="Oxu-EE-kDP"/>
+                        <constraint firstItem="cZc-Nb-vxf" firstAttribute="top" secondItem="dgS-YB-bvH" secondAttribute="bottom" constant="44" id="bdf-7I-jdh"/>
+                        <constraint firstItem="cZc-Nb-vxf" firstAttribute="leading" secondItem="1eY-fr-ddQ" secondAttribute="leading" constant="20" id="egI-8s-riJ"/>
+                        <constraint firstItem="ljr-Y9-NfJ" firstAttribute="top" secondItem="cZc-Nb-vxf" secondAttribute="bottom" constant="28" id="fDy-bW-uRZ"/>
+                        <constraint firstAttribute="trailing" secondItem="ljr-Y9-NfJ" secondAttribute="trailing" constant="20" id="inu-Qt-7OV"/>
+                        <constraint firstAttribute="bottom" secondItem="KeA-dZ-aEK" secondAttribute="bottom" id="nfV-96-hQf"/>
+                        <constraint firstAttribute="trailing" secondItem="dgS-YB-bvH" secondAttribute="trailing" constant="20" id="pZh-Am-AAp"/>
+                        <constraint firstItem="ljr-Y9-NfJ" firstAttribute="leading" secondItem="1eY-fr-ddQ" secondAttribute="leading" constant="20" id="uXu-Rq-NP7"/>
+                    </constraints>
+                </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="KeA-dZ-aEK" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="50b-4M-YVG"/>
-                <constraint firstItem="cZc-Nb-vxf" firstAttribute="top" secondItem="dgS-YB-bvH" secondAttribute="bottom" constant="44" id="5hs-FW-Y6f"/>
-                <constraint firstItem="ljr-Y9-NfJ" firstAttribute="top" secondItem="cZc-Nb-vxf" secondAttribute="bottom" constant="28" id="Bcd-Ew-ixR"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="dgS-YB-bvH" secondAttribute="trailing" constant="20" id="Ha1-wa-XMq"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="cZc-Nb-vxf" secondAttribute="trailing" constant="20" id="MWU-56-h14"/>
-                <constraint firstItem="cZc-Nb-vxf" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="P0b-8w-Bnx"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="ljr-Y9-NfJ" secondAttribute="trailing" constant="20" id="PgN-ne-SbS"/>
-                <constraint firstItem="KeA-dZ-aEK" firstAttribute="top" secondItem="ljr-Y9-NfJ" secondAttribute="bottom" constant="28" id="Rf3-dB-eTo"/>
-                <constraint firstItem="dgS-YB-bvH" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="evY-xa-kvJ"/>
+                <constraint firstItem="1eY-fr-ddQ" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="HrE-YV-Ldt"/>
                 <constraint firstItem="3jM-k7-QOd" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="kLg-b2-pPt"/>
+                <constraint firstItem="1eY-fr-ddQ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="mV6-D2-cCC"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="3jM-k7-QOd" secondAttribute="bottom" constant="22" id="r6Y-QA-y6K"/>
-                <constraint firstItem="ljr-Y9-NfJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="uTi-hD-6Ij"/>
+                <constraint firstItem="1eY-fr-ddQ" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="sK3-r1-f6Y"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="3jM-k7-QOd" secondAttribute="trailing" constant="20" id="vrd-VZ-Msm"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="KeA-dZ-aEK" secondAttribute="trailing" constant="20" id="wfF-K4-EhK"/>
-                <constraint firstItem="dgS-YB-bvH" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="22" id="yNQ-id-dzl"/>
             </constraints>
-            <point key="canvasLocation" x="133" y="91"/>
+            <point key="canvasLocation" x="131.8840579710145" y="90.401785714285708"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->

회원가입뷰의 기능을 구현하였습니다~

🌱 작업한 브랜치

- feature/#39
- feature/#38

🌱 작업한 내용

#39
> 텍스트필드들이 키보드에 가려지는 이슈 해결
- QKeyboardManager 를 이용하여 텍스트필드를 선택하면 자동으로 뷰가 올라가도록 구현
- 네비게이션바 커스텀

#38
- 이메일, 비밀번호의 조건 검사 (정규식 이용)
(비밀번호 조건에 대해 디자인/기획팀과 이야기 나눈 후 수정이 들어갈 수 있습니다!)
- 비밀번호 재입력과 비밀번호 비교
- 조건에 따라 각각 경고문구가 뜨거나 텍스트필드 테두리가 빨강색으로 보이게 만들기
- 세가지 조건이 다 맞다면 버튼 활성화하기

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  |![Simulator Screen Recording - iPhone 13 mini - 2022-01-14 at 06 45 46](https://user-images.githubusercontent.com/75469131/149415118-7914f06b-4ce2-45dc-8c93-d9635b43760c.gif)|


## 📮 관련 이슈

- Resolved: #38 
- Resolved: #39 
