### PR TITLE
[#115] 닉네임 검색 뷰 서버연결

### DIFF
--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		9A3DF0AF279742C400D07A8C /* SaveNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0AD279742C400D07A8C /* SaveNicknameViewController.swift */; };
 		9A3DF0B0279742C400D07A8C /* SaveNicknameViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A3DF0AE279742C400D07A8C /* SaveNicknameViewController.xib */; };
 		9A3DF0B427981C6A00D07A8C /* SearchNicknameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0B327981C6A00D07A8C /* SearchNicknameModel.swift */; };
+		9A3DF0B727981D8600D07A8C /* AddAccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0B627981D8600D07A8C /* AddAccountService.swift */; };
 		9A9E620A278D575800D900A6 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9E6208278D575800D900A6 /* SignUpViewController.swift */; };
 		9A9E620B278D575800D900A6 /* SignUpViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9E6209278D575800D900A6 /* SignUpViewController.xib */; };
 		9ADB609D2794E2CC00FDC7ED /* SenderInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A62FAB27918AC7003425A1 /* SenderInfoCollectionViewCell.swift */; };
@@ -176,6 +177,7 @@
 		9A3DF0AD279742C400D07A8C /* SaveNicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveNicknameViewController.swift; sourceTree = "<group>"; };
 		9A3DF0AE279742C400D07A8C /* SaveNicknameViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SaveNicknameViewController.xib; sourceTree = "<group>"; };
 		9A3DF0B327981C6A00D07A8C /* SearchNicknameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchNicknameModel.swift; sourceTree = "<group>"; };
+		9A3DF0B627981D8600D07A8C /* AddAccountService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAccountService.swift; sourceTree = "<group>"; };
 		9A9E6208278D575800D900A6 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		9A9E6209278D575800D900A6 /* SignUpViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignUpViewController.xib; sourceTree = "<group>"; };
 		9ADEBC4E2794213000B13417 /* CompleteSignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteSignUpViewController.swift; sourceTree = "<group>"; };
@@ -357,6 +359,7 @@
 		9A3DF0B127981C1500D07A8C /* Account */ = {
 			isa = PBXGroup;
 			children = (
+				9A3DF0B627981D8600D07A8C /* AddAccountService.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -886,7 +889,6 @@
 		ECB845DB279567D700433522 /* APIServices */ = {
 			isa = PBXGroup;
 			children = (
-				9A3DF0B127981C1500D07A8C /* Account */,
 				ECB845DD2795681E00433522 /* NetworkResult.swift */,
 				ECB845DF2795684E00433522 /* GenericResponse.swift */,
 				BD7120EC2796B15B0068B981 /* APIConstants.swift */,
@@ -895,6 +897,7 @@
 				ECB845E22795771B00433522 /* Medicine */,
 				BD7120E62796A5FB0068B981 /* Home */,
 				BD7120F2279717370068B981 /* Share */,
+				9A3DF0B127981C1500D07A8C /* Account */,
 			);
 			path = APIServices;
 			sourceTree = "<group>";
@@ -1280,6 +1283,7 @@
 				BD9857A22791CA97009883FC /* CalendarViewController.swift in Sources */,
 				9A3DF09B2796E04900D07A8C /* SignInAPI.swift in Sources */,
 				BDDAA5A92789BCD3000C0AF8 /* UserDefaultKey.swift in Sources */,
+				9A3DF0B727981D8600D07A8C /* AddAccountService.swift in Sources */,
 				F6538FB0278DBBC100B20B5E /* SendInfoCollectionViewCell.swift in Sources */,
 				BDDAA5AE2789BCD3000C0AF8 /* Text.swift in Sources */,
 				9A3DF0962796B24D00D07A8C /* SignUpDataModel.swift in Sources */,

--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		9A3DF0AB2797252300D07A8C /* SearchNicknameViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A3DF0A92797252300D07A8C /* SearchNicknameViewController.xib */; };
 		9A3DF0AF279742C400D07A8C /* SaveNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0AD279742C400D07A8C /* SaveNicknameViewController.swift */; };
 		9A3DF0B0279742C400D07A8C /* SaveNicknameViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A3DF0AE279742C400D07A8C /* SaveNicknameViewController.xib */; };
+		9A3DF0B427981C6A00D07A8C /* SearchNicknameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0B327981C6A00D07A8C /* SearchNicknameModel.swift */; };
 		9A9E620A278D575800D900A6 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9E6208278D575800D900A6 /* SignUpViewController.swift */; };
 		9A9E620B278D575800D900A6 /* SignUpViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9E6209278D575800D900A6 /* SignUpViewController.xib */; };
 		9ADB609D2794E2CC00FDC7ED /* SenderInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A62FAB27918AC7003425A1 /* SenderInfoCollectionViewCell.swift */; };
@@ -174,6 +175,7 @@
 		9A3DF0A92797252300D07A8C /* SearchNicknameViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchNicknameViewController.xib; sourceTree = "<group>"; };
 		9A3DF0AD279742C400D07A8C /* SaveNicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveNicknameViewController.swift; sourceTree = "<group>"; };
 		9A3DF0AE279742C400D07A8C /* SaveNicknameViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SaveNicknameViewController.xib; sourceTree = "<group>"; };
+		9A3DF0B327981C6A00D07A8C /* SearchNicknameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchNicknameModel.swift; sourceTree = "<group>"; };
 		9A9E6208278D575800D900A6 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		9A9E6209278D575800D900A6 /* SignUpViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignUpViewController.xib; sourceTree = "<group>"; };
 		9ADEBC4E2794213000B13417 /* CompleteSignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteSignUpViewController.swift; sourceTree = "<group>"; };
@@ -350,6 +352,21 @@
 				9A3DF09A2796E04900D07A8C /* SignInAPI.swift */,
 			);
 			path = SignIn;
+			sourceTree = "<group>";
+		};
+		9A3DF0B127981C1500D07A8C /* Account */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Account;
+			sourceTree = "<group>";
+		};
+		9A3DF0B227981C4D00D07A8C /* Account */ = {
+			isa = PBXGroup;
+			children = (
+				9A3DF0B327981C6A00D07A8C /* SearchNicknameModel.swift */,
+			);
+			path = Account;
 			sourceTree = "<group>";
 		};
 		BD2C8B3A27953B7300B1F59D /* PagerTab */ = {
@@ -869,14 +886,15 @@
 		ECB845DB279567D700433522 /* APIServices */ = {
 			isa = PBXGroup;
 			children = (
+				9A3DF0B127981C1500D07A8C /* Account */,
 				ECB845DD2795681E00433522 /* NetworkResult.swift */,
 				ECB845DF2795684E00433522 /* GenericResponse.swift */,
+				BD7120EC2796B15B0068B981 /* APIConstants.swift */,
 				9A3DF0992796DE5300D07A8C /* SignIn */,
 				9A3DF09027966A1900D07A8C /* SignUp */,
 				ECB845E22795771B00433522 /* Medicine */,
 				BD7120E62796A5FB0068B981 /* Home */,
 				BD7120F2279717370068B981 /* Share */,
-				BD7120EC2796B15B0068B981 /* APIConstants.swift */,
 			);
 			path = APIServices;
 			sourceTree = "<group>";
@@ -884,6 +902,7 @@
 		ECB845DC279567E700433522 /* APIModel */ = {
 			isa = PBXGroup;
 			children = (
+				9A3DF0B227981C4D00D07A8C /* Account */,
 				BD7120F7279723950068B981 /* Share */,
 				BD7120E72796A60D0068B981 /* Home */,
 				9A3DF08D279660B000D07A8C /* Sign */,
@@ -1195,6 +1214,7 @@
 				9A3DF09D2796E30D00D07A8C /* SignInModel.swift in Sources */,
 				F6538FB3278DCF8600B20B5E /* SendInfoListDataModel.swift in Sources */,
 				BD149DCD278B3369009AA416 /* TabBarController.swift in Sources */,
+				9A3DF0B427981C6A00D07A8C /* SearchNicknameModel.swift in Sources */,
 				BD7120EF2796B3850068B981 /* ScheduleAPI.swift in Sources */,
 				EC03760E278B2E4000CA4B54 /* AddMedicineSheet.swift in Sources */,
 				BD2C8B3C27953B8100B1F59D /* PagerTab.swift in Sources */,

--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		9A3DF0B0279742C400D07A8C /* SaveNicknameViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A3DF0AE279742C400D07A8C /* SaveNicknameViewController.xib */; };
 		9A3DF0B427981C6A00D07A8C /* SearchNicknameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0B327981C6A00D07A8C /* SearchNicknameModel.swift */; };
 		9A3DF0B727981D8600D07A8C /* AddAccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0B627981D8600D07A8C /* AddAccountService.swift */; };
+		9A3DF0B92798250A00D07A8C /* AddAccontAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0B82798250A00D07A8C /* AddAccontAPI.swift */; };
+		9A3DF0BB279832F800D07A8C /* SearchNicknameDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0BA279832F800D07A8C /* SearchNicknameDataModel.swift */; };
 		9A9E620A278D575800D900A6 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9E6208278D575800D900A6 /* SignUpViewController.swift */; };
 		9A9E620B278D575800D900A6 /* SignUpViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9E6209278D575800D900A6 /* SignUpViewController.xib */; };
 		9ADB609D2794E2CC00FDC7ED /* SenderInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A62FAB27918AC7003425A1 /* SenderInfoCollectionViewCell.swift */; };
@@ -178,6 +180,8 @@
 		9A3DF0AE279742C400D07A8C /* SaveNicknameViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SaveNicknameViewController.xib; sourceTree = "<group>"; };
 		9A3DF0B327981C6A00D07A8C /* SearchNicknameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchNicknameModel.swift; sourceTree = "<group>"; };
 		9A3DF0B627981D8600D07A8C /* AddAccountService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAccountService.swift; sourceTree = "<group>"; };
+		9A3DF0B82798250A00D07A8C /* AddAccontAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAccontAPI.swift; sourceTree = "<group>"; };
+		9A3DF0BA279832F800D07A8C /* SearchNicknameDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchNicknameDataModel.swift; sourceTree = "<group>"; };
 		9A9E6208278D575800D900A6 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		9A9E6209278D575800D900A6 /* SignUpViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignUpViewController.xib; sourceTree = "<group>"; };
 		9ADEBC4E2794213000B13417 /* CompleteSignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteSignUpViewController.swift; sourceTree = "<group>"; };
@@ -360,6 +364,7 @@
 			isa = PBXGroup;
 			children = (
 				9A3DF0B627981D8600D07A8C /* AddAccountService.swift */,
+				9A3DF0B82798250A00D07A8C /* AddAccontAPI.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -555,6 +560,7 @@
 				F67CDBF1278B4B8D00F70974 /* NoticeListDataModel.swift */,
 				F6538FB2278DCF8600B20B5E /* SendInfoListDataModel.swift */,
 				9A3DF0952796B24D00D07A8C /* SignUpDataModel.swift */,
+				9A3DF0BA279832F800D07A8C /* SearchNicknameDataModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -905,11 +911,11 @@
 		ECB845DC279567E700433522 /* APIModel */ = {
 			isa = PBXGroup;
 			children = (
-				9A3DF0B227981C4D00D07A8C /* Account */,
 				BD7120F7279723950068B981 /* Share */,
 				BD7120E72796A60D0068B981 /* Home */,
 				9A3DF08D279660B000D07A8C /* Sign */,
 				ECB845E92795775F00433522 /* Medicine */,
+				9A3DF0B227981C4D00D07A8C /* Account */,
 			);
 			path = APIModel;
 			sourceTree = "<group>";
@@ -1224,6 +1230,7 @@
 				ECECEF98278C6CB1003D1454 /* AddMyMedicineViewController.swift in Sources */,
 				BD7120F6279722A50068B981 /* ShareAPI.swift in Sources */,
 				ECB845E82795774B00433522 /* PillCountService.swift in Sources */,
+				9A3DF0B92798250A00D07A8C /* AddAccontAPI.swift in Sources */,
 				EC037612278B2EAF00CA4B54 /* AddMedicineTableViewCell.swift in Sources */,
 				BDD21AA3278D92B2007D10F6 /* MedicineCollectionViewCell.swift in Sources */,
 				9A3DF09227966A3A00D07A8C /* SignUpAPI.swift in Sources */,
@@ -1277,6 +1284,7 @@
 				9ADEBC502794213000B13417 /* CompleteSignUpViewController.swift in Sources */,
 				BD515E3B278770C5003BD5A4 /* SceneDelegate.swift in Sources */,
 				EC1C31132792F12E00972404 /* MedicineTimeViewController.swift in Sources */,
+				9A3DF0BB279832F800D07A8C /* SearchNicknameDataModel.swift in Sources */,
 				BDD21A9A278D8705007D10F6 /* HomeViewController.swift in Sources */,
 				EC950EF82790A88D00A34027 /* AddTimeCollectionViewCell.swift in Sources */,
 				9A3DF0982796DE4900D07A8C /* SignInService.swift in Sources */,

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/Account/SearchNicknameModel.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/Account/SearchNicknameModel.swift
@@ -7,18 +7,8 @@
 
 import Foundation
 
-// MARK: - SearchNickname
-struct SearchNickname: Codable {
-    let data: SearchNicknameResult?
-}
-
-// MARK: - SearchNicknameResult
-struct SearchNicknameResult: Codable {
-    let memberID: Int
+// MARK: - SearchNicknameData
+struct SearchNicknameData: Codable {
+    let memberId: Int
     let memberName: String
-
-    enum CodingKeys: String, CodingKey {
-        case memberID = "memberId"
-        case memberName
-    }
 }

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/Account/SearchNicknameModel.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/Account/SearchNicknameModel.swift
@@ -1,0 +1,24 @@
+//
+//  SearchNicknameModel.swift
+//  SobokSobok
+//
+//  Created by 김선오 on 2022/01/19.
+//
+
+import Foundation
+
+// MARK: - SearchNickname
+struct SearchNickname: Codable {
+    let data: SearchNicknameResult?
+}
+
+// MARK: - SearchNicknameResult
+struct SearchNicknameResult: Codable {
+    let memberID: Int
+    let memberName: String
+
+    enum CodingKeys: String, CodingKey {
+        case memberID = "memberId"
+        case memberName
+    }
+}

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/Account/SearchNicknameModel.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/Account/SearchNicknameModel.swift
@@ -9,6 +9,6 @@ import Foundation
 
 // MARK: - SearchNicknameData
 struct SearchNicknameData: Codable {
-    let memberId: Int
-    let memberName: String
+    let memberId: Int?
+    let memberName: String?
 }

--- a/SobokSobok/SobokSobok/Data/Model/SearchNicknameDataModel.swift
+++ b/SobokSobok/SobokSobok/Data/Model/SearchNicknameDataModel.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class SearchedUser {
     static let shared = SearchedUser()
-    var username: String?
+    var searchedUsername: String?
+    var searchedUserId: Int?
     var savedName: String?
 }

--- a/SobokSobok/SobokSobok/Data/Model/SearchNicknameDataModel.swift
+++ b/SobokSobok/SobokSobok/Data/Model/SearchNicknameDataModel.swift
@@ -1,0 +1,14 @@
+//
+//  SearchNicknameDataModel.swift
+//  SobokSobok
+//
+//  Created by 김선오 on 2022/01/19.
+//
+
+import UIKit
+
+class SearchedUser {
+    static let shared = SearchedUser()
+    var username: String?
+    var savedName: String?
+}

--- a/SobokSobok/SobokSobok/Presentation/Account/SaveNicknameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Account/SaveNicknameViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 final class SaveNicknameViewController: BaseViewController {
 
     // MARK: - Properties
-    var nickname: String?
     private var nameCount: Int = 0
     
     // MARK: - @IBOutlet Properties
@@ -34,7 +33,7 @@ final class SaveNicknameViewController: BaseViewController {
     
     // MARK: - Functions
     private func setNickname() {
-        if let nickname = nickname {
+        if let nickname = SearchedUser.shared.searchedUsername {
             nicknameTextLabel.text = nickname
             nicknameTextLabel.sizeToFit()
         }

--- a/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.swift
@@ -15,7 +15,7 @@ final class SearchNicknameViewController: BaseViewController {
     @IBOutlet weak var resultButton: UIButton!
     @IBOutlet weak var resultTextLabel: UILabel!
     @IBOutlet weak var noResultImageView: UIImageView!
-    
+        
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -35,15 +35,15 @@ final class SearchNicknameViewController: BaseViewController {
     
     // 검색결과가 없을때
     private func setNoSearchResult() {
-        resultTextLabel.text = searchNicknameTextField.text ?? ""
-        resultTextLabel.isHidden = false
-        noResultImageView.isHidden = true
+        resultTextLabel.isHidden = true
+        noResultImageView.isHidden = false
     }
     
     // 검색결과가 있을때
     private func setYesSearchResult() {
-        resultTextLabel.isHidden = true
-        noResultImageView.isHidden = false
+        resultTextLabel.text = searchNicknameTextField.text ?? ""
+        resultTextLabel.isHidden = false
+        noResultImageView.isHidden = true
     }
     
     // MARK: - @IBAction Properties
@@ -54,7 +54,7 @@ final class SearchNicknameViewController: BaseViewController {
     @IBAction func touchUpToAddFriend(_ sender: Any) {
         // 닉네임 저장 (다음 뷰에서 사용하기 위함)
         searchedUser.username = resultTextLabel.text
-        
+
         // 화면 전환
         let nextVC = SaveNicknameViewController.instanceFromNib()
         nextVC.nickname = resultTextLabel.text ?? ""
@@ -78,8 +78,8 @@ extension SearchNicknameViewController {
         AddAccountAPI.shared.searchNickname(username: username, completion: {(result) in
             switch result {
             case .success(let data):
-                print(data)
-                if data == nil {
+                guard let data = data as? [SearchNicknameData] else { return }
+                if data.isEmpty {
                     self.setNoSearchResult()
                 } else {
                     self.setYesSearchResult()

--- a/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class SearchNicknameViewController: BaseViewController {
 
     // MARK: - @IBOutlet Properties
+    private var searchedUser = SearchedUser.shared
     @IBOutlet weak var searchNicknameTextField: UITextField!
     @IBOutlet weak var resultButton: UIButton!
     @IBOutlet weak var resultTextLabel: UILabel!
@@ -32,12 +33,29 @@ final class SearchNicknameViewController: BaseViewController {
         searchNicknameTextField.delegate = self
     }
     
+    // 검색결과가 없을때
+    private func setNoSearchResult() {
+        resultTextLabel.text = searchNicknameTextField.text ?? ""
+        resultTextLabel.isHidden = false
+        noResultImageView.isHidden = true
+    }
+    
+    // 검색결과가 있을때
+    private func setYesSearchResult() {
+        resultTextLabel.isHidden = true
+        noResultImageView.isHidden = false
+    }
+    
     // MARK: - @IBAction Properties
     @IBAction func touchUpToClose(_ sender: Any) {
         dismiss(animated: true)
     }
     
     @IBAction func touchUpToAddFriend(_ sender: Any) {
+        // 닉네임 저장 (다음 뷰에서 사용하기 위함)
+        searchedUser.username = resultTextLabel.text
+        
+        // 화면 전환
         let nextVC = SaveNicknameViewController.instanceFromNib()
         nextVC.nickname = resultTextLabel.text ?? ""
         navigationController?.pushViewController(nextVC, animated: true)
@@ -46,16 +64,35 @@ final class SearchNicknameViewController: BaseViewController {
 
 extension SearchNicknameViewController: UITextFieldDelegate {
   func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-      if searchNicknameTextField.text != "no" {
-          resultTextLabel.text = searchNicknameTextField.text ?? ""
-          resultTextLabel.isHidden = false
-          noResultImageView.isHidden = true
-          searchNicknameTextField.resignFirstResponder()
-    } else {
-        resultTextLabel.isHidden = true
-        noResultImageView.isHidden = false
-        searchNicknameTextField.resignFirstResponder()
-    }
+      searchNickname()
+      searchNicknameTextField.resignFirstResponder()
     return true
   }
+}
+
+extension SearchNicknameViewController {
+    func searchNickname() {
+        guard let username = searchNicknameTextField.text else {
+                   return
+        }
+        AddAccountAPI.shared.searchNickname(username: username, completion: {(result) in
+            switch result {
+            case .success(let data):
+                print(data)
+                if data == nil {
+                    self.setNoSearchResult()
+                } else {
+                    self.setYesSearchResult()
+                }
+            case .requestErr(let message):
+                print("requestErr", message)
+            case .pathErr:
+                print(".pathErr")
+            case .serverErr:
+                print("serverErr")
+            case .networkFail:
+                print("networkFail")
+            }
+        })
+    }
 }

--- a/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 final class SearchNicknameViewController: BaseViewController {
 
     // MARK: - @IBOutlet Properties
-    private var searchedUser = SearchedUser.shared
     @IBOutlet weak var searchNicknameTextField: UITextField!
     @IBOutlet weak var resultButton: UIButton!
     @IBOutlet weak var resultTextLabel: UILabel!
@@ -45,19 +44,15 @@ final class SearchNicknameViewController: BaseViewController {
         resultTextLabel.isHidden = false
         noResultImageView.isHidden = true
     }
-    
+        
     // MARK: - @IBAction Properties
     @IBAction func touchUpToClose(_ sender: Any) {
         dismiss(animated: true)
     }
     
     @IBAction func touchUpToAddFriend(_ sender: Any) {
-        // 닉네임 저장 (다음 뷰에서 사용하기 위함)
-        searchedUser.username = resultTextLabel.text
-
         // 화면 전환
         let nextVC = SaveNicknameViewController.instanceFromNib()
-        nextVC.nickname = resultTextLabel.text ?? ""
         navigationController?.pushViewController(nextVC, animated: true)
     }
 }
@@ -83,6 +78,10 @@ extension SearchNicknameViewController {
                     self.setNoSearchResult()
                 } else {
                     self.setYesSearchResult()
+                    
+                    // 데이터 전달 (다음 뷰에서 사용하기 위함)
+                    SearchedUser.shared.searchedUserId = data[0].memberId
+                    SearchedUser.shared.searchedUsername = data[0].memberName
                 }
             case .requestErr(let message):
                 print("requestErr", message)

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccontAPI.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccontAPI.swift
@@ -1,0 +1,53 @@
+//
+//  AddAccontAPI.swift
+//  SobokSobok
+//
+//  Created by 김선오 on 2022/01/19.
+//
+
+import Foundation
+import Moya
+
+public struct AddAccountAPI {
+    
+    static let shared = AddAccountAPI()
+    var addAccountProvider = MoyaProvider<AddAccountService>()
+    
+    private init() { }
+    
+    func searchNickname(username: String, completion: @escaping (NetworkResult<Any>) -> Void) {
+        addAccountProvider.request(.searchNickname(username: username)) { (result) in
+            switch result {
+            case.success(let response):
+                
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                let networkResult = self.judgeStatus(by: statusCode, data)
+                completion(networkResult)
+                
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    private func judgeStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(GenericResponse<SearchNicknameResult>.self, from: data)
+        else {
+            return .pathErr
+        }
+        
+        switch statusCode {
+        case 200:
+            return .success(decodedData.data as Any)
+        case 400..<500:
+            return .requestErr(decodedData.message as Any)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
+}

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccontAPI.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccontAPI.swift
@@ -34,7 +34,7 @@ public struct AddAccountAPI {
     
     private func judgeStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<SearchNicknameResult>.self, from: data)
+        guard let decodedData = try? decoder.decode(GenericResponse<[SearchNicknameData]>.self, from: data)
         else {
             return .pathErr
         }

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccountService.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccountService.swift
@@ -1,0 +1,54 @@
+//
+//  SearchNicknameService.swift
+//  SobokSobok
+//
+//  Created by 김선오 on 2022/01/19.
+//
+
+import Foundation
+import Moya
+
+enum AddAccountService {
+    case searchNickname(username: String)
+}
+
+extension AddAccountService: TargetType {
+    var baseURL: URL {
+        return URL(string: URLs.baseURL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .searchNickname(let username):
+            return URLs.getFriendsURL + "?username=\(username)"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .searchNickname(_):
+            return .get
+        }
+    }
+    
+    var sampleData: Data {
+            return Data()
+    }
+    
+    var task: Task {
+        switch self {
+        case .searchNickname:
+            return .requestPlain
+        }
+    }
+    
+    var headers: [String: String]? {
+        switch self {
+        case .searchNickname:
+            return [
+                "Content-Type": "application/json",
+                "accesstoken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjIsImVtYWlsIjoiZWRAZ21haWwuY29tIiwibmFtZSI6bnVsbCwiaWRGaXJlYmFzZSI6InVOR2llMWxKWDNTREpTQnFSWHhLZUhqMnJhMzMiLCJpYXQiOjE2NDE4ODYzNjUsImV4cCI6MTY0NDQ3ODM2NSwiaXNzIjoid2Vzb3B0In0.K9xOhsd1G3sHAo89LRbLHaPySX8PeOW3kxvbbYaVeNA"
+            ]
+        }
+    }
+}

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccountService.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccountService.swift
@@ -19,8 +19,8 @@ extension AddAccountService: TargetType {
     
     var path: String {
         switch self {
-        case .searchNickname(let username):
-            return URLs.getFriendsURL + "?username=\(username)"
+        case .searchNickname(_):
+            return URLs.getFriendsURL
         }
     }
     
@@ -32,13 +32,13 @@ extension AddAccountService: TargetType {
     }
     
     var sampleData: Data {
-            return Data()
+        return Data()
     }
     
     var task: Task {
         switch self {
-        case .searchNickname:
-            return .requestPlain
+        case .searchNickname(let username):
+            return .requestParameters(parameters: ["username": username], encoding: URLEncoding.queryString)
         }
     }
     
@@ -47,7 +47,7 @@ extension AddAccountService: TargetType {
         case .searchNickname:
             return [
                 "Content-Type": "application/json",
-                "accesstoken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjIsImVtYWlsIjoiZWRAZ21haWwuY29tIiwibmFtZSI6bnVsbCwiaWRGaXJlYmFzZSI6InVOR2llMWxKWDNTREpTQnFSWHhLZUhqMnJhMzMiLCJpYXQiOjE2NDE4ODYzNjUsImV4cCI6MTY0NDQ3ODM2NSwiaXNzIjoid2Vzb3B0In0.K9xOhsd1G3sHAo89LRbLHaPySX8PeOW3kxvbbYaVeNA"
+                "accesstoken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjYsImVtYWlsIjoidGVzdEBnbWFpbC5jb20iLCJuYW1lIjpudWxsLCJpZEZpcmViYXNlIjoiTnBRVmhYdUg3eVUwUkpVdUV6Zks3NldWckFGMiIsImlhdCI6MTY0MjA5MjkwMiwiZXhwIjoxNjQ0Njg0OTAyLCJpc3MiOiJ3ZXNvcHQifQ.fZ4bodbWJ3AlgD_c0oE5OyAW2WaXDeQHtApZLaZjdGI"
             ]
         }
     }


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->

계정 추가 플로우의 계정 공유 요청 - 닉네임 겁색 뷰의 API를 연결했습니다
(feat. 쿼리 parameter 가 있는... Get...)

🌱 작업한 브랜치

- feature/#115

🌱 작업한 내용

- 서버통신으로 닉네임 검색하기
- 검색한 닉네임 데이터 다음 화면에 전달하기

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | ![Simulator Screen Recording - iPhone 12 mini - 2022-01-20 at 01 20 28](https://user-images.githubusercontent.com/75469131/150171719-3d81b687-cd45-43cb-b906-6180f75a6b60.gif) |

## 📮 관련 이슈

- Resolved: #115