### PR TITLE
[#117] 이름 저장 뷰 서버연결

### DIFF
--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		9A3DF0B727981D8600D07A8C /* AddAccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0B627981D8600D07A8C /* AddAccountService.swift */; };
 		9A3DF0B92798250A00D07A8C /* AddAccontAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0B82798250A00D07A8C /* AddAccontAPI.swift */; };
 		9A3DF0BB279832F800D07A8C /* SearchNicknameDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0BA279832F800D07A8C /* SearchNicknameDataModel.swift */; };
+		9A3DF0BD27987A7400D07A8C /* SaveNicknameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0BC27987A7300D07A8C /* SaveNicknameModel.swift */; };
 		9A9E620A278D575800D900A6 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9E6208278D575800D900A6 /* SignUpViewController.swift */; };
 		9A9E620B278D575800D900A6 /* SignUpViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9E6209278D575800D900A6 /* SignUpViewController.xib */; };
 		9ADB609D2794E2CC00FDC7ED /* SenderInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A62FAB27918AC7003425A1 /* SenderInfoCollectionViewCell.swift */; };
@@ -182,6 +183,7 @@
 		9A3DF0B627981D8600D07A8C /* AddAccountService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAccountService.swift; sourceTree = "<group>"; };
 		9A3DF0B82798250A00D07A8C /* AddAccontAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAccontAPI.swift; sourceTree = "<group>"; };
 		9A3DF0BA279832F800D07A8C /* SearchNicknameDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchNicknameDataModel.swift; sourceTree = "<group>"; };
+		9A3DF0BC27987A7300D07A8C /* SaveNicknameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveNicknameModel.swift; sourceTree = "<group>"; };
 		9A9E6208278D575800D900A6 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		9A9E6209278D575800D900A6 /* SignUpViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignUpViewController.xib; sourceTree = "<group>"; };
 		9ADEBC4E2794213000B13417 /* CompleteSignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteSignUpViewController.swift; sourceTree = "<group>"; };
@@ -373,6 +375,7 @@
 			isa = PBXGroup;
 			children = (
 				9A3DF0B327981C6A00D07A8C /* SearchNicknameModel.swift */,
+				9A3DF0BC27987A7300D07A8C /* SaveNicknameModel.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -1220,6 +1223,7 @@
 				BD51AE372790A97400314A94 /* StickerBottomSheet.swift in Sources */,
 				ECB845ED279594E400433522 /* URLs.swift in Sources */,
 				BD515E6F2787784D003BD5A4 /* BaseViewController.swift in Sources */,
+				9A3DF0BD27987A7400D07A8C /* SaveNicknameModel.swift in Sources */,
 				9A3DF09D2796E30D00D07A8C /* SignInModel.swift in Sources */,
 				F6538FB3278DCF8600B20B5E /* SendInfoListDataModel.swift in Sources */,
 				BD149DCD278B3369009AA416 /* TabBarController.swift in Sources */,

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/Account/SaveNicknameModel.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/Account/SaveNicknameModel.swift
@@ -1,0 +1,20 @@
+//
+//  SaveNicknameModel.swift
+//  SobokSobok
+//
+//  Created by 김선오 on 2022/01/20.
+//
+
+import Foundation
+
+// MARK: - DataClass
+struct SaveNicknameData {
+    let sendGroupID: Int?
+    let senderID: Int?
+    let senderName: String?
+    let memberID: Int?
+    let memberName: String?
+    let isSend: Bool?
+    let isOkay: NSNull?
+    let createdAt: String?
+}

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/Account/SaveNicknameModel.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/Account/SaveNicknameModel.swift
@@ -7,14 +7,48 @@
 
 import Foundation
 
-// MARK: - DataClass
-struct SaveNicknameData {
-    let sendGroupID: Int?
-    let senderID: Int?
+// MARK: - SaveNicknameData
+struct SaveNicknameData: Codable {
+    let sendGroupID, senderID: Int?
     let senderName: String?
     let memberID: Int?
     let memberName: String?
     let isSend: Bool?
-    let isOkay: NSNull?
+    let isOkay: JSONNull?
     let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case sendGroupID
+        case senderID
+        case senderName
+        case memberID
+        case memberName, isSend, isOkay, createdAt
+    }
+}
+
+// MARK: - Encode/decode helpers
+
+class JSONNull: Codable, Hashable {
+
+    public static func == (lhs: JSONNull, rhs: JSONNull) -> Bool {
+        return true
+    }
+
+    public var hashValue: Int {
+        return 0
+    }
+
+    public init() {}
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if !container.decodeNil() {
+            throw DecodingError.typeMismatch(JSONNull.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for JSONNull"))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encodeNil()
+    }
 }

--- a/SobokSobok/SobokSobok/Data/Model/SearchNicknameDataModel.swift
+++ b/SobokSobok/SobokSobok/Data/Model/SearchNicknameDataModel.swift
@@ -11,5 +11,4 @@ class SearchedUser {
     static let shared = SearchedUser()
     var searchedUsername: String?
     var searchedUserId: Int?
-    var savedName: String?
 }

--- a/SobokSobok/SobokSobok/Presentation/Account/SaveNicknameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Account/SaveNicknameViewController.swift
@@ -101,6 +101,28 @@ final class SaveNicknameViewController: BaseViewController {
     }
     
     @IBAction func touchUpToRequest(_ sender: UIButton) {
-        print("request")
+        saveNickname()
+    }
+}
+
+extension SaveNicknameViewController {
+    func saveNickname() {
+        guard let memberID = SearchedUser.shared.searchedUserId else { return }
+        guard let savedName = self.searchTextField.text else { return }
+        
+        AddAccountAPI.shared.saveNickname(memberId: memberID, memberName: savedName, completion: {(result) in
+            switch result {
+            case .success(let data):
+                print(data)
+            case .requestErr(let message):
+                print("requestErr", message)
+            case .pathErr:
+                print(".pathErr")
+            case .serverErr:
+                print("serverErr")
+            case .networkFail:
+                print("networkFail")
+            }
+        })
     }
 }

--- a/SobokSobok/SobokSobok/Presentation/Account/SaveNicknameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Account/SaveNicknameViewController.swift
@@ -87,6 +87,29 @@ final class SaveNicknameViewController: BaseViewController {
         counterTextLabel.textColor = UIColor(cgColor: Color.gray600.cgColor)
         requestButton.isEnabled = true
     }
+    // 토스트 메세지
+    private func showToast(message: String) {
+        var toastLabel = UILabel()
+        // 토스트 위치
+        toastLabel = UILabel(frame: CGRect(x: 20,
+                                           y: self.view.frame.size.height - 95,
+                                           width: self.view.frame.size.width - 40,
+                                           height: 47))
+        // 토스트 색
+        toastLabel.backgroundColor = Color.black
+        toastLabel.textColor = Color.white
+        // 토스트 값
+        toastLabel.text = message
+        // 토스트 모양
+        toastLabel.textAlignment = .center
+        toastLabel.layer.cornerRadius = 12
+        toastLabel.clipsToBounds = true
+        // 토스트 애니메이션
+        self.view.addSubview(toastLabel)
+        UIView.animate(withDuration: 1.5, delay: 0.1,
+                       options: .curveEaseIn, animations: { toastLabel.alpha = 0.0 },
+                       completion: {_ in toastLabel.removeFromSuperview() })
+    }
     
     // 정규식 체크
     private func checkIsIncludeSpecial (input: String) -> Bool {
@@ -114,8 +137,8 @@ extension SaveNicknameViewController {
             switch result {
             case .success(let data):
                 print(data)
-            case .requestErr(let message):
-                print("requestErr", message)
+            case .requestErr(_):
+                self.showToast(message: "이미 추가된 사람이에요")
             case .pathErr:
                 print(".pathErr")
             case .serverErr:

--- a/SobokSobok/SobokSobok/Presentation/Account/SaveNicknameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Account/SaveNicknameViewController.swift
@@ -90,7 +90,7 @@ final class SaveNicknameViewController: BaseViewController {
     
     // 정규식 체크
     private func checkIsIncludeSpecial (input: String) -> Bool {
-        let validNickName = "[A-Za-z가-힣0-9]{1,10}"
+        let validNickName = "[A-Za-z가-힣0-9ㄱ-ㅎㅏ-ㅣ]{1,10}"
         let nickNameTest = NSPredicate(format: "SELF MATCHES %@", validNickName)
           return nickNameTest.evaluate(with: input)
     }

--- a/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.xib
@@ -102,7 +102,7 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="illustNoNotice" translatesAutoresizingMaskIntoConstraints="NO" id="8d7-rm-x9E">
-                    <rect key="frame" x="48" y="441" width="318" height="218"/>
+                    <rect key="frame" x="48" y="394" width="318" height="218"/>
                 </imageView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pCk-zB-dDT" userLabel="결과">
                     <rect key="frame" x="20" y="233" width="374" height="25"/>
@@ -130,7 +130,7 @@
                 <constraint firstItem="qRg-i3-dei" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="KbH-b5-DbW"/>
                 <constraint firstItem="pCk-zB-dDT" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="LR2-ub-pDw"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="pCk-zB-dDT" secondAttribute="trailing" constant="20" id="PYA-YD-8Wr"/>
-                <constraint firstItem="8d7-rm-x9E" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" constant="102" id="X3M-rT-mEp"/>
+                <constraint firstItem="8d7-rm-x9E" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" constant="55" id="alz-fH-s1L"/>
                 <constraint firstItem="Y5J-Mh-Uk5" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="bC2-P1-rlr"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Y5J-Mh-Uk5" secondAttribute="trailing" constant="20" id="iIA-gt-V94"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="whR-HL-dZI" secondAttribute="trailing" constant="20" id="mHs-dG-R2w"/>

--- a/SobokSobok/SobokSobok/Presentation/Common/BaseViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Common/BaseViewController.swift
@@ -21,4 +21,5 @@ class BaseViewController: UIViewController {
     }
     public func hierarchy() {}
     public func layout() {}
+    
 }

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccontAPI.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccontAPI.swift
@@ -33,8 +33,7 @@ public struct AddAccountAPI {
     }
     
     func saveNickname(memberId: Int, memberName: String, completion: @escaping (NetworkResult<Any>) -> Void) {
-        addAccountProvider.request(.saveNickname(memberId: memberId, memberName: memberName)) {
-            (result) in
+        addAccountProvider.request(.saveNickname(memberId: memberId, memberName: memberName)) { (result) in
             switch result {
             case .success(let response):
                 let statusCode = response.statusCode

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccontAPI.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccontAPI.swift
@@ -23,7 +23,7 @@ public struct AddAccountAPI {
                 let statusCode = response.statusCode
                 let data = response.data
                 
-                let networkResult = self.judgeStatus(by: statusCode, data)
+                let networkResult = self.judgeStatus(by: statusCode, data, [SearchNicknameData].self)
                 completion(networkResult)
                 
             case .failure(let err):
@@ -32,9 +32,26 @@ public struct AddAccountAPI {
         }
     }
     
-    private func judgeStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+    func saveNickname(memberId: Int, memberName: String, completion: @escaping (NetworkResult<Any>) -> Void) {
+        addAccountProvider.request(.saveNickname(memberId: memberId, memberName: memberName)) {
+            (result) in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                let networkResult = self.judgeStatus(by: statusCode, data, [SaveNicknameData].self)
+                completion(networkResult)
+                
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    private func judgeStatus<T: Codable>(by statusCode: Int, _ data: Data, _ object: T.Type?) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<[SearchNicknameData]>.self, from: data)
+        guard let decodedData = try? decoder.decode(GenericResponse<T>.self, from: data)
         else {
             return .pathErr
         }

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccountService.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccountService.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum AddAccountService {
     case searchNickname(username: String)
+    case saveNickname(memberId: Int, memberName: String)
 }
 
 extension AddAccountService: TargetType {
@@ -21,6 +22,8 @@ extension AddAccountService: TargetType {
         switch self {
         case .searchNickname(_):
             return URLs.getFriendsURL
+        case .saveNickname(_,_):
+            return URLs.postCalendarURL
         }
     }
     
@@ -28,6 +31,8 @@ extension AddAccountService: TargetType {
         switch self {
         case .searchNickname(_):
             return .get
+        case .saveNickname(_,_):
+            return .post
         }
     }
     
@@ -39,12 +44,14 @@ extension AddAccountService: TargetType {
         switch self {
         case .searchNickname(let username):
             return .requestParameters(parameters: ["username": username], encoding: URLEncoding.queryString)
+        case .saveNickname(let memberId, _):
+            return .requestParameters(parameters: ["memberId": memberId], encoding: URLEncoding.queryString)
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .searchNickname:
+        case .searchNickname, .saveNickname:
             return [
                 "Content-Type": "application/json",
                 "accesstoken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjYsImVtYWlsIjoidGVzdEBnbWFpbC5jb20iLCJuYW1lIjpudWxsLCJpZEZpcmViYXNlIjoiTnBRVmhYdUg3eVUwUkpVdUV6Zks3NldWckFGMiIsImlhdCI6MTY0MjA5MjkwMiwiZXhwIjoxNjQ0Njg0OTAyLCJpc3MiOiJ3ZXNvcHQifQ.fZ4bodbWJ3AlgD_c0oE5OyAW2WaXDeQHtApZLaZjdGI"

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccountService.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccountService.swift
@@ -22,8 +22,8 @@ extension AddAccountService: TargetType {
         switch self {
         case .searchNickname(_):
             return URLs.getFriendsURL
-        case .saveNickname(_,_):
-            return URLs.postCalendarURL
+        case .saveNickname(_, _):
+            return "/group"
         }
     }
     
@@ -31,7 +31,7 @@ extension AddAccountService: TargetType {
         switch self {
         case .searchNickname(_):
             return .get
-        case .saveNickname(_,_):
+        case .saveNickname(_, _):
             return .post
         }
     }
@@ -44,8 +44,8 @@ extension AddAccountService: TargetType {
         switch self {
         case .searchNickname(let username):
             return .requestParameters(parameters: ["username": username], encoding: URLEncoding.queryString)
-        case .saveNickname(let memberId, _):
-            return .requestParameters(parameters: ["memberId": memberId], encoding: URLEncoding.queryString)
+        case .saveNickname(let memberId, let memberName):
+            return .requestCompositeParameters(bodyParameters: ["memberName": memberName], bodyEncoding: JSONEncoding.default, urlParameters: ["memberId": memberId])
         }
     }
     

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccountService.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Account/AddAccountService.swift
@@ -23,7 +23,7 @@ extension AddAccountService: TargetType {
         case .searchNickname(_):
             return URLs.getFriendsURL
         case .saveNickname(_, _):
-            return "/group"
+            return URLs.postCalendarURL
         }
     }
     


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->

계정 추가 플로우에서 계정 공유 요청 - 이름 저장 뷰의 서버를 연결합니다.
이제 계정 추가 요청 보낼 수 있어요!

🌱 작업한 브랜치

- feature/#117

🌱 작업한 내용

- 이름 저장 조건 추가 (자음만, 모음만)
- 계정 공유 요청 - 이름저장 뷰 서버통신
- "이미 추가된 사람이에요" 토스트메세지

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | ![Simulator Screen Recording - iPhone 11 Pro - 2022-01-20 at 06 29 02](https://user-images.githubusercontent.com/75469131/150216839-ee35de5a-a5ac-45b0-872c-69638d7fcc2b.gif) |

## 📮 관련 이슈

- Resolved: #117
