### PR TITLE
[#125] 친구 이름 수정 서버 연결

### DIFF
--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		9A3DF0C62798CE4300D07A8C /* EditFriendNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0C42798CE4300D07A8C /* EditFriendNameViewController.swift */; };
 		9A3DF0C72798CE4300D07A8C /* EditFriendNameViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A3DF0C52798CE4300D07A8C /* EditFriendNameViewController.xib */; };
 		9A3DF0C92799EFEC00D07A8C /* EditFriendUsername.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0C82799EFEB00D07A8C /* EditFriendUsername.swift */; };
+		9A3DF0CD2799F4C800D07A8C /* EditFriendDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0CC2799F4C800D07A8C /* EditFriendDataModel.swift */; };
 		9A9E620A278D575800D900A6 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9E6208278D575800D900A6 /* SignUpViewController.swift */; };
 		9A9E620B278D575800D900A6 /* SignUpViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9E6209278D575800D900A6 /* SignUpViewController.xib */; };
 		9ADB609D2794E2CC00FDC7ED /* SenderInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A62FAB27918AC7003425A1 /* SenderInfoCollectionViewCell.swift */; };
@@ -197,6 +198,7 @@
 		9A3DF0C42798CE4300D07A8C /* EditFriendNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditFriendNameViewController.swift; sourceTree = "<group>"; };
 		9A3DF0C52798CE4300D07A8C /* EditFriendNameViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditFriendNameViewController.xib; sourceTree = "<group>"; };
 		9A3DF0C82799EFEB00D07A8C /* EditFriendUsername.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditFriendUsername.swift; sourceTree = "<group>"; };
+		9A3DF0CC2799F4C800D07A8C /* EditFriendDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditFriendDataModel.swift; sourceTree = "<group>"; };
 		9A9E6208278D575800D900A6 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		9A9E6209278D575800D900A6 /* SignUpViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignUpViewController.xib; sourceTree = "<group>"; };
 		9ADEBC4E2794213000B13417 /* CompleteSignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteSignUpViewController.swift; sourceTree = "<group>"; };
@@ -593,6 +595,7 @@
 				F67CDBF1278B4B8D00F70974 /* NoticeListDataModel.swift */,
 				F6538FB2278DCF8600B20B5E /* SendInfoListDataModel.swift */,
 				9A3DF0952796B24D00D07A8C /* SignUpDataModel.swift */,
+				9A3DF0CC2799F4C800D07A8C /* EditFriendDataModel.swift */,
 				9A3DF0BA279832F800D07A8C /* SearchNicknameDataModel.swift */,
 			);
 			path = Model;
@@ -1281,6 +1284,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A3DF0CD2799F4C800D07A8C /* EditFriendDataModel.swift in Sources */,
 				9A18E7AB278D48120011FEB9 /* SignInViewController.swift in Sources */,
 				ECECEF9C278C7079003D1454 /* AddMyMedicineCollectionViewCell.swift in Sources */,
 				BD7120F9279723A00068B981 /* Member.swift in Sources */,

--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		9A3DF0BD27987A7400D07A8C /* SaveNicknameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0BC27987A7300D07A8C /* SaveNicknameModel.swift */; };
 		9A3DF0C62798CE4300D07A8C /* EditFriendNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0C42798CE4300D07A8C /* EditFriendNameViewController.swift */; };
 		9A3DF0C72798CE4300D07A8C /* EditFriendNameViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A3DF0C52798CE4300D07A8C /* EditFriendNameViewController.xib */; };
+		9A3DF0C92799EFEC00D07A8C /* EditFriendUsername.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DF0C82799EFEB00D07A8C /* EditFriendUsername.swift */; };
 		9A9E620A278D575800D900A6 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9E6208278D575800D900A6 /* SignUpViewController.swift */; };
 		9A9E620B278D575800D900A6 /* SignUpViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9E6209278D575800D900A6 /* SignUpViewController.xib */; };
 		9ADB609D2794E2CC00FDC7ED /* SenderInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A62FAB27918AC7003425A1 /* SenderInfoCollectionViewCell.swift */; };
@@ -195,6 +196,7 @@
 		9A3DF0BC27987A7300D07A8C /* SaveNicknameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveNicknameModel.swift; sourceTree = "<group>"; };
 		9A3DF0C42798CE4300D07A8C /* EditFriendNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditFriendNameViewController.swift; sourceTree = "<group>"; };
 		9A3DF0C52798CE4300D07A8C /* EditFriendNameViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditFriendNameViewController.xib; sourceTree = "<group>"; };
+		9A3DF0C82799EFEB00D07A8C /* EditFriendUsername.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditFriendUsername.swift; sourceTree = "<group>"; };
 		9A9E6208278D575800D900A6 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		9A9E6209278D575800D900A6 /* SignUpViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignUpViewController.xib; sourceTree = "<group>"; };
 		9ADEBC4E2794213000B13417 /* CompleteSignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteSignUpViewController.swift; sourceTree = "<group>"; };
@@ -817,6 +819,7 @@
 			isa = PBXGroup;
 			children = (
 				BD7120F8279723A00068B981 /* Member.swift */,
+				9A3DF0C82799EFEB00D07A8C /* EditFriendUsername.swift */,
 			);
 			path = Share;
 			sourceTree = "<group>";
@@ -1289,6 +1292,7 @@
 				F6538FB3278DCF8600B20B5E /* SendInfoListDataModel.swift in Sources */,
 				BD149DCD278B3369009AA416 /* TabBarController.swift in Sources */,
 				9A3DF0B427981C6A00D07A8C /* SearchNicknameModel.swift in Sources */,
+				9A3DF0C92799EFEC00D07A8C /* EditFriendUsername.swift in Sources */,
 				BD7120EF2796B3850068B981 /* ScheduleAPI.swift in Sources */,
 				EC03760E278B2E4000CA4B54 /* AddMedicineSheet.swift in Sources */,
 				BD2C8B3C27953B8100B1F59D /* PagerTab.swift in Sources */,

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/Share/EditFriendUsername.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/Share/EditFriendUsername.swift
@@ -1,0 +1,21 @@
+//
+//  EditFriendUsername.swift
+//  SobokSobok
+//
+//  Created by 김선오 on 2022/01/21.
+//
+
+import Foundation
+
+// MARK: - EditFriendUsername
+struct EditFriendUsername: Codable {
+    let groupID, userID, memberID: Int
+    let memberName: String
+
+    enum CodingKeys: String, CodingKey {
+        case groupID
+        case userID
+        case memberID
+        case memberName
+    }
+}

--- a/SobokSobok/SobokSobok/Data/Model/EditFriendDataModel.swift
+++ b/SobokSobok/SobokSobok/Data/Model/EditFriendDataModel.swift
@@ -1,0 +1,14 @@
+//
+//  EditFriendDataModel.swift
+//  SobokSobok
+//
+//  Created by 김선오 on 2022/01/21.
+//
+
+import UIKit
+
+class EditFriend {
+    static let shared = EditFriend()
+    var groupId: Int = 31
+    var memberName: String?
+}

--- a/SobokSobok/SobokSobok/Data/Model/EditFriendDataModel.swift
+++ b/SobokSobok/SobokSobok/Data/Model/EditFriendDataModel.swift
@@ -9,6 +9,6 @@ import UIKit
 
 class EditFriend {
     static let shared = EditFriend()
-    var groupId: Int = 31
+    var groupId: Int?
     var memberName: String?
 }

--- a/SobokSobok/SobokSobok/Presentation/EditFriendName/EditFriendNameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/EditFriendName/EditFriendNameViewController.swift
@@ -95,9 +95,34 @@ final class EditFriendNameViewController: BaseViewController {
     
     // MARK: - @IBAction Properties
     @IBAction func touchUpToConfirm(_ sender: Any) {
+        EditFriend.shared.groupId = 31 //화면 연결되면 전달 받아야함
+        EditFriend.shared.memberName = nameTextField.text ?? ""
+        editFriendName()
     }
     
     @IBAction func touchUpToDIsmiss(_ sender: Any) {
     }
     
+}
+
+extension EditFriendNameViewController {
+    func editFriendName() {
+        guard let groupId = EditFriend.shared.groupId else { return }
+        guard let memberName = EditFriend.shared.memberName else { return }
+        
+        ShareAPI.shared.editFriendUsername(groupId: groupId, memberName: memberName, completion: {(result) in
+            switch result {
+            case .success(let data):
+                print(data)
+            case .requestErr(let message):
+                print("requestErr", message)
+            case .pathErr:
+                print(".pathErr")
+            case .serverErr:
+                print("serverErr")
+            case .networkFail:
+                print("networkFail")
+            }
+        })
+    }
 }

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Share/ShareAPI.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Share/ShareAPI.swift
@@ -65,6 +65,23 @@ struct ShareAPI {
             }
         }
     }
+    
+    public func editFriendUsername(groupId: Int, memberName: String, completion: @escaping(NetworkResult<Any>) -> Void) {
+        shareProvider.request(.editFriendUsername(groupId: groupId, memberName: memberName)) { (result) in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                let networkResult = self.judgeStatus(by: statusCode, data, [EditFriendUsername].self)
+                completion(networkResult)
+                
+            case .failure(let err):
+                print(err)
+            }
+            
+        }
+    }
 
     private func judgeStatus<T: Codable>(by statusCode: Int, _ data: Data, _ object: T.Type) -> NetworkResult<Any> {
         let decoder = JSONDecoder()

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Share/ShareService.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Share/ShareService.swift
@@ -60,8 +60,13 @@ extension ShareService: TargetType {
 
     var headers: [String: String]? {
         switch self {
-        case .getGroupInfomation, .getFriendCalendar, .getFriendPillList, .editFriendUsername:
+        case .getGroupInfomation, .getFriendCalendar, .getFriendPillList:
             return APIConstants.headerWithToken
+            
+        case .editFriendUsername:
+            return [
+                "accesstoken": APIConstants.accessToken27
+            ]
         }
     }
 }

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Share/ShareService.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Share/ShareService.swift
@@ -14,6 +14,7 @@ enum ShareService {
     case getGroupInfomation
     case getFriendCalendar(memberId: Int, date: String)
     case getFriendPillList(memberId: Int, date: String)
+    case editFriendUsername(groupId: Int, memberName: String)
 }
 
 extension ShareService: TargetType {
@@ -29,6 +30,9 @@ extension ShareService: TargetType {
             return URLs.getFriendCalendarURL.replacingOccurrences(of: "{memberId}", with: "\(memberId)")
         case .getFriendPillList(let memberId, _):
             return URLs.getFriendPillListURL.replacingOccurrences(of: "{memberId}", with: "\(memberId)")
+            
+        case .editFriendUsername(let groupId, _):
+            return URLs.editFriendUsernameURL.replacingOccurrences(of: "{groupId}", with: "\(groupId)")
         }
     }
 
@@ -36,6 +40,9 @@ extension ShareService: TargetType {
         switch self {
         case .getGroupInfomation, .getFriendCalendar, .getFriendPillList:
             return .get
+            
+        case .editFriendUsername:
+            return .put
         }
     }
 
@@ -45,12 +52,15 @@ extension ShareService: TargetType {
             return .requestPlain
         case .getFriendCalendar(_, let date), .getFriendPillList(_, let date):
             return .requestParameters(parameters: ["date": date], encoding: URLEncoding.queryString)
+            
+        case .editFriendUsername(_, let memberName):
+            return .requestParameters(parameters: ["memberName": memberName], encoding: JSONEncoding.default)
         }
     }
 
     var headers: [String: String]? {
         switch self {
-        case .getGroupInfomation, .getFriendCalendar, .getFriendPillList:
+        case .getGroupInfomation, .getFriendCalendar, .getFriendPillList, .editFriendUsername:
             return APIConstants.headerWithToken
         }
     }


### PR DESCRIPTION
## 🌴 PR 요약

공유탭의 친구 이름 수정 뷰에 서버를 연결합니다

🌱 작업한 브랜치

- feature/#125

🌱 작업한 내용

- 친구 이름 수정 뷰 서버 연결

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | 파일첨부바람 |

## 📮 관련 이슈

- Resolved: #125 
