### PR TITLE
[#138] 네비게이션 바 오토레이아웃 재설정

### DIFF
--- a/SobokSobok/SobokSobok/Presentation/Account/SaveNicknameViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/Account/SaveNicknameViewController.xib
@@ -38,10 +38,10 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EVm-0s-1SU" userLabel="네비게이션">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="102"/>
+                    <rect key="frame" x="0.0" y="44" width="414" height="70"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yBQ-Ui-RDk">
-                            <rect key="frame" x="0.0" y="45" width="48" height="48"/>
+                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yBQ-Ui-RDk">
+                            <rect key="frame" x="0.0" y="13" width="48" height="48"/>
                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                             <state key="normal" image="icBack48"/>
                             <connections>
@@ -49,7 +49,7 @@
                             </connections>
                         </button>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="공유 요청하기" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JPh-Mh-oMc">
-                            <rect key="frame" x="77" y="59" width="260" height="20.5"/>
+                            <rect key="frame" x="77" y="28.5" width="260" height="20.5"/>
                             <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="17"/>
                             <color key="textColor" name="gray900_sub"/>
                             <nil key="highlightedColor"/>
@@ -58,16 +58,14 @@
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstItem="yBQ-Ui-RDk" firstAttribute="leading" secondItem="EVm-0s-1SU" secondAttribute="leading" id="25u-lS-3Cn"/>
-                        <constraint firstAttribute="bottom" secondItem="yBQ-Ui-RDk" secondAttribute="bottom" constant="9" id="P9J-B6-K4s"/>
+                        <constraint firstAttribute="bottom" secondItem="JPh-Mh-oMc" secondAttribute="bottom" constant="21" id="J0J-DE-QXD"/>
                         <constraint firstItem="JPh-Mh-oMc" firstAttribute="leading" secondItem="EVm-0s-1SU" secondAttribute="leading" constant="77" id="WNc-Th-7Ax"/>
-                        <constraint firstAttribute="height" constant="102" id="fdI-kD-90t"/>
+                        <constraint firstAttribute="height" constant="70" id="fdI-kD-90t"/>
                         <constraint firstAttribute="trailing" secondItem="JPh-Mh-oMc" secondAttribute="trailing" constant="77" id="tcQ-TO-N1P"/>
-                        <constraint firstItem="JPh-Mh-oMc" firstAttribute="centerY" secondItem="yBQ-Ui-RDk" secondAttribute="centerY" id="x7a-P7-Itf"/>
-                        <constraint firstItem="yBQ-Ui-RDk" firstAttribute="top" secondItem="EVm-0s-1SU" secondAttribute="top" constant="45" id="zn3-ab-JXO"/>
                     </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JAp-UO-oTM">
-                    <rect key="frame" x="20" y="129" width="320.5" height="18.5"/>
+                    <rect key="frame" x="20" y="141" width="320.5" height="18.5"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="닉네임이10글자시네요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ozy-82-ehV">
                             <rect key="frame" x="0.0" y="0.0" width="133.5" height="18.5"/>
@@ -87,7 +85,7 @@
                     </constraints>
                 </stackView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fi1-Y4-NQK" userLabel="검색">
-                    <rect key="frame" x="20" y="158.5" width="374" height="54"/>
+                    <rect key="frame" x="20" y="170.5" width="374" height="54"/>
                     <subviews>
                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="2~10글자의 한글, 영문, 숫자" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="SA2-9W-tha">
                             <rect key="frame" x="17" y="15" width="342" height="24"/>
@@ -106,7 +104,7 @@
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R78-2I-rWP">
-                    <rect key="frame" x="20" y="240.5" width="374" height="46"/>
+                    <rect key="frame" x="20" y="252.5" width="374" height="46"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icNotice" translatesAutoresizingMaskIntoConstraints="NO" id="eEl-Pm-QSD">
                             <rect key="frame" x="14" y="13" width="20" height="20"/>
@@ -141,7 +139,7 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="6 / 10" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K5D-a5-coz">
-                    <rect key="frame" x="361" y="215.5" width="33" height="18"/>
+                    <rect key="frame" x="361" y="227.5" width="33" height="18"/>
                     <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="13"/>
                     <color key="textColor" name="gray600_sub"/>
                     <nil key="highlightedColor"/>
@@ -166,7 +164,7 @@
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="특수문자 입력은 불가능해요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZJR-Fe-L6i">
-                    <rect key="frame" x="20" y="215.5" width="141.5" height="18"/>
+                    <rect key="frame" x="20" y="227.5" width="141.5" height="18"/>
                     <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="13"/>
                     <color key="textColor" name="pill_color_red"/>
                     <nil key="highlightedColor"/>
@@ -179,7 +177,7 @@
                 <constraint firstItem="fi1-Y4-NQK" firstAttribute="top" secondItem="JAp-UO-oTM" secondAttribute="bottom" constant="11" id="Cnn-3m-SsS"/>
                 <constraint firstItem="fi1-Y4-NQK" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="Kq3-DM-AEv"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="K5D-a5-coz" secondAttribute="trailing" constant="20" id="Ve9-99-7RJ"/>
-                <constraint firstItem="EVm-0s-1SU" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="Ybu-6I-88o"/>
+                <constraint firstItem="EVm-0s-1SU" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Ybu-6I-88o"/>
                 <constraint firstItem="K5D-a5-coz" firstAttribute="top" secondItem="fi1-Y4-NQK" secondAttribute="bottom" constant="3" id="ces-aE-ZZN"/>
                 <constraint firstItem="Ygj-IR-wBA" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="db0-yk-s57"/>
                 <constraint firstItem="R78-2I-rWP" firstAttribute="top" secondItem="ZJR-Fe-L6i" secondAttribute="bottom" constant="7" id="dfN-Fb-aHd"/>

--- a/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.xib
@@ -36,22 +36,16 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="추가할 사람의 닉네임을 입력해 주세요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="whR-HL-dZI">
-                    <rect key="frame" x="20" y="129" width="374" height="19"/>
+                    <rect key="frame" x="20" y="141" width="374" height="19"/>
                     <fontDescription key="fontDescription" name="Pretendard-SemiBold" family="Pretendard" pointSize="15"/>
                     <color key="textColor" name="gray800_sub"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m3g-Pc-vFL" userLabel="네비게이션">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="102"/>
+                    <rect key="frame" x="0.0" y="44" width="414" height="70"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="공유 요청하기" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g0B-yQ-lOk">
-                            <rect key="frame" x="77" y="59" width="260" height="20.5"/>
-                            <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="17"/>
-                            <color key="textColor" name="gray900_sub"/>
-                            <nil key="highlightedColor"/>
-                        </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V4A-yS-mvd">
-                            <rect key="frame" x="0.0" y="45" width="48" height="48"/>
+                            <rect key="frame" x="0.0" y="15" width="48" height="48"/>
                             <color key="tintColor" name="black_sub"/>
                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                             <state key="normal" image="icClose48"/>
@@ -59,19 +53,25 @@
                                 <action selector="touchUpToClose:" destination="-1" eventType="touchUpInside" id="3Fj-Lt-KI5"/>
                             </connections>
                         </button>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="공유 요청하기" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g0B-yQ-lOk">
+                            <rect key="frame" x="77" y="28.5" width="260" height="20.5"/>
+                            <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="17"/>
+                            <color key="textColor" name="gray900_sub"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                     </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstItem="g0B-yQ-lOk" firstAttribute="leading" secondItem="m3g-Pc-vFL" secondAttribute="leading" constant="77" id="6JB-OH-5MQ"/>
-                        <constraint firstAttribute="height" constant="102" id="BU9-cx-gTd"/>
-                        <constraint firstItem="V4A-yS-mvd" firstAttribute="top" secondItem="m3g-Pc-vFL" secondAttribute="top" constant="45" id="Puf-2j-Klc"/>
-                        <constraint firstItem="V4A-yS-mvd" firstAttribute="centerY" secondItem="g0B-yQ-lOk" secondAttribute="centerY" id="PvO-xz-cd9"/>
+                        <constraint firstAttribute="height" constant="70" id="BU9-cx-gTd"/>
+                        <constraint firstItem="V4A-yS-mvd" firstAttribute="centerY" secondItem="g0B-yQ-lOk" secondAttribute="centerY" id="QX2-W3-zUI"/>
                         <constraint firstItem="V4A-yS-mvd" firstAttribute="leading" secondItem="m3g-Pc-vFL" secondAttribute="leading" id="kSp-lH-aKr"/>
                         <constraint firstAttribute="trailing" secondItem="g0B-yQ-lOk" secondAttribute="trailing" constant="77" id="mtF-qW-Ap9"/>
+                        <constraint firstAttribute="bottom" secondItem="g0B-yQ-lOk" secondAttribute="bottom" constant="21" id="oTV-Lt-eWo"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qRg-i3-dei" userLabel="검색">
-                    <rect key="frame" x="20" y="159" width="374" height="54"/>
+                    <rect key="frame" x="20" y="171" width="374" height="54"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="magnifyingglass" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="8lU-Hs-3Hd">
                             <rect key="frame" x="15" y="15.5" width="20.5" height="22.5"/>
@@ -105,7 +105,7 @@
                     <rect key="frame" x="48" y="394" width="318" height="218"/>
                 </imageView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pCk-zB-dDT" userLabel="결과">
-                    <rect key="frame" x="20" y="233" width="374" height="25"/>
+                    <rect key="frame" x="20" y="245" width="374" height="25"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="25" id="DP3-wU-O8z"/>
                     </constraints>
@@ -115,7 +115,7 @@
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="적복이" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y5J-Mh-Uk5">
-                    <rect key="frame" x="20" y="234.5" width="374" height="22"/>
+                    <rect key="frame" x="20" y="246.5" width="374" height="22"/>
                     <fontDescription key="fontDescription" name="Pretendard-SemiBold" family="Pretendard" pointSize="18"/>
                     <color key="textColor" name="gray900_sub"/>
                     <nil key="highlightedColor"/>
@@ -124,7 +124,7 @@
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="m3g-Pc-vFL" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="0ED-FU-vBb"/>
+                <constraint firstItem="m3g-Pc-vFL" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="0ED-FU-vBb"/>
                 <constraint firstItem="whR-HL-dZI" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="FO2-wN-mB1"/>
                 <constraint firstItem="Y5J-Mh-Uk5" firstAttribute="centerY" secondItem="pCk-zB-dDT" secondAttribute="centerY" id="Glh-ON-c35"/>
                 <constraint firstItem="qRg-i3-dei" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="KbH-b5-DbW"/>

--- a/SobokSobok/SobokSobok/Presentation/EditFriendName/EditFriendNameViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/EditFriendName/EditFriendNameViewController.xib
@@ -34,16 +34,16 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="emU-5k-Nej" userLabel="네비게이션">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="102"/>
+                    <rect key="frame" x="0.0" y="44" width="414" height="70"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이름 수정" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xLj-vV-bsf">
-                            <rect key="frame" x="77" y="61" width="260" height="20"/>
+                            <rect key="frame" x="77" y="29" width="260" height="20"/>
                             <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="17"/>
                             <color key="textColor" name="gray900_sub"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b7r-tj-ouZ">
-                            <rect key="frame" x="1" y="47" width="48" height="48"/>
+                            <rect key="frame" x="1" y="15" width="48" height="48"/>
                             <color key="tintColor" name="black_sub"/>
                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                             <state key="normal" image="icClose48"/>
@@ -52,7 +52,7 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Enn-N8-eJT">
-                            <rect key="frame" x="355.5" y="55.5" width="48.5" height="31"/>
+                            <rect key="frame" x="355.5" y="23.5" width="48.5" height="31"/>
                             <color key="tintColor" name="mint_main"/>
                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                             <state key="normal" title="확인"/>
@@ -67,7 +67,7 @@
                         <constraint firstItem="Enn-N8-eJT" firstAttribute="centerY" secondItem="xLj-vV-bsf" secondAttribute="centerY" id="2Ut-sD-tfq"/>
                         <constraint firstAttribute="bottom" secondItem="xLj-vV-bsf" secondAttribute="bottom" constant="21" id="6Rl-gr-R3T"/>
                         <constraint firstAttribute="trailing" secondItem="Enn-N8-eJT" secondAttribute="trailing" constant="10" id="AgG-hO-IKL"/>
-                        <constraint firstAttribute="height" constant="102" id="GHd-TR-Ufd"/>
+                        <constraint firstAttribute="height" constant="70" id="GHd-TR-Ufd"/>
                         <constraint firstAttribute="trailing" secondItem="xLj-vV-bsf" secondAttribute="trailing" constant="77" id="Swl-u2-4Wa"/>
                         <constraint firstItem="xLj-vV-bsf" firstAttribute="leading" secondItem="emU-5k-Nej" secondAttribute="leading" constant="77" id="j7X-ap-CTT"/>
                         <constraint firstItem="b7r-tj-ouZ" firstAttribute="centerY" secondItem="xLj-vV-bsf" secondAttribute="centerY" id="jib-BS-d8y"/>
@@ -75,7 +75,7 @@
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="52p-ov-AwO" userLabel="텍스트필드">
-                    <rect key="frame" x="20" y="132" width="374" height="54"/>
+                    <rect key="frame" x="20" y="144" width="374" height="54"/>
                     <subviews>
                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="수혀니" placeholder="수혀니" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="qwZ-Bz-7bT">
                             <rect key="frame" x="15" y="15" width="344" height="24"/>
@@ -94,13 +94,13 @@
                     </constraints>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2자 이상 입력 가능해요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="frf-VE-ax3">
-                    <rect key="frame" x="30" y="189" width="118.5" height="16"/>
+                    <rect key="frame" x="30" y="201" width="118.5" height="16"/>
                     <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="13"/>
                     <color key="textColor" name="pill_color_red"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1 / 10" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zyR-Yg-DY4">
-                    <rect key="frame" x="353" y="189" width="31" height="16"/>
+                    <rect key="frame" x="353" y="201" width="31" height="16"/>
                     <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="13"/>
                     <color key="textColor" name="pill_color_red"/>
                     <nil key="highlightedColor"/>
@@ -116,7 +116,7 @@
                 <constraint firstItem="frf-VE-ax3" firstAttribute="top" secondItem="52p-ov-AwO" secondAttribute="bottom" constant="3" id="bcJ-Ii-YO9"/>
                 <constraint firstItem="emU-5k-Nej" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="ctS-Ip-AGH"/>
                 <constraint firstItem="zyR-Yg-DY4" firstAttribute="top" secondItem="52p-ov-AwO" secondAttribute="bottom" constant="3" id="hIs-id-wZL"/>
-                <constraint firstItem="emU-5k-Nej" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="nDr-ZZ-tR8"/>
+                <constraint firstItem="emU-5k-Nej" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="nDr-ZZ-tR8"/>
                 <constraint firstItem="frf-VE-ax3" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="30" id="sUz-rI-t7p"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="52p-ov-AwO" secondAttribute="trailing" constant="20" id="tdl-JF-fdk"/>
             </constraints>

--- a/SobokSobok/SobokSobok/Presentation/SignUp/CompleteSignUpViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/CompleteSignUpViewController.xib
@@ -29,10 +29,10 @@
                     <rect key="frame" x="80" y="282.5" width="254" height="271"/>
                 </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yEi-Cn-QyM">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="102"/>
+                    <rect key="frame" x="0.0" y="44" width="414" height="70"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="회윈가입 완료" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N9X-Mc-PQU">
-                            <rect key="frame" x="160.5" y="60" width="93" height="21"/>
+                            <rect key="frame" x="160.5" y="28" width="93" height="21"/>
                             <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="17"/>
                             <color key="textColor" name="gray900_sub"/>
                             <nil key="highlightedColor"/>
@@ -41,7 +41,7 @@
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="bottom" secondItem="N9X-Mc-PQU" secondAttribute="bottom" constant="21" id="498-NO-aCS"/>
-                        <constraint firstAttribute="height" constant="102" id="gBw-Ud-caF"/>
+                        <constraint firstAttribute="height" constant="70" id="gBw-Ud-caF"/>
                         <constraint firstItem="N9X-Mc-PQU" firstAttribute="centerX" secondItem="yEi-Cn-QyM" secondAttribute="centerX" id="zj2-sH-alO"/>
                     </constraints>
                 </view>
@@ -76,9 +76,9 @@
                 <constraint firstItem="nin-Uy-O2q" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="UgE-Z5-8EY"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="nin-Uy-O2q" secondAttribute="bottom" constant="22" id="fgA-Ct-Nso"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="yEi-Cn-QyM" secondAttribute="trailing" id="j3D-iL-Jzf"/>
-                <constraint firstItem="yEi-Cn-QyM" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="jNo-Jq-7FE"/>
+                <constraint firstItem="yEi-Cn-QyM" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="jNo-Jq-7FE"/>
             </constraints>
-            <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+            <nil key="simulatedTopBarMetrics"/>
             <point key="canvasLocation" x="133" y="80"/>
         </view>
     </objects>

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SetNickNameVIewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SetNickNameVIewController.swift
@@ -69,7 +69,7 @@ final class SetNickNameVIewController: BaseViewController {
         
         // 조건에 따라 버튼 활성화
         [signUpButton, checkDuplicationButton].forEach({$0?.isEnabled = isNickNameRight})
-        checkDuplicationButtonBottomLine.backgroundColor = isNickNameRight ? UIColor(cgColor: Color.darkMint.cgColor) : UIColor(cgColor: Color.gray500.cgColor)
+        checkDuplicationButtonBottomLine.backgroundColor = isNickNameRight ? UIColor(cgColor: Color.darkMint.cgColor) : UIColor(cgColor: Color.gray400.cgColor)
     }
     
     // 입력 완료했을 때

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SetNickNameVIewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SetNickNameVIewController.xib
@@ -121,12 +121,11 @@
                     <color key="textColor" name="pill_color_red"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ATZ-VC-f9q">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ATZ-VC-f9q">
                     <rect key="frame" x="20" y="788" width="374" height="52"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="52" id="hW3-6X-aIL"/>
                     </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
                     <color key="tintColor" name="mint_main"/>
                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                     <state key="normal" title="회원가입"/>
@@ -143,7 +142,7 @@
                     </connections>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ePI-CH-nAs" userLabel="밑줄">
-                    <rect key="frame" x="334" y="363" width="52" height="1"/>
+                    <rect key="frame" x="334" y="360" width="52" height="1"/>
                     <color key="backgroundColor" name="gray500_sub"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="E12-nk-9X8"/>
@@ -162,7 +161,7 @@
                 <constraint firstItem="Lkl-cX-QCB" firstAttribute="top" secondItem="4t0-cf-gZv" secondAttribute="bottom" constant="18" id="FW6-Zu-u3v"/>
                 <constraint firstItem="mFd-jy-tVf" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Iwy-2A-C53"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Lkl-cX-QCB" secondAttribute="trailing" constant="28" id="JKY-K4-FOJ"/>
-                <constraint firstItem="ePI-CH-nAs" firstAttribute="top" secondItem="Lkl-cX-QCB" secondAttribute="bottom" id="P7N-6D-ZLo"/>
+                <constraint firstItem="ePI-CH-nAs" firstAttribute="top" secondItem="Lkl-cX-QCB" secondAttribute="bottom" constant="-3" id="P7N-6D-ZLo"/>
                 <constraint firstItem="Fcf-fc-fjJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="S1O-rX-tAf"/>
                 <constraint firstItem="ATZ-VC-f9q" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="SYy-NT-CHi"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="mFd-jy-tVf" secondAttribute="trailing" id="Tjb-Sb-B8E"/>

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SetNickNameVIewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SetNickNameVIewController.xib
@@ -39,16 +39,16 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mFd-jy-tVf">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="102"/>
+                    <rect key="frame" x="0.0" y="44" width="414" height="70"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="회원가입" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HDr-YN-wJC">
-                            <rect key="frame" x="177.5" y="61" width="59" height="20"/>
+                            <rect key="frame" x="177.5" y="29" width="59" height="20"/>
                             <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="17"/>
                             <color key="textColor" name="gray900_sub"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ym3-5Q-qVu">
-                            <rect key="frame" x="1" y="47" width="48" height="48"/>
+                            <rect key="frame" x="1" y="15" width="48" height="48"/>
                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                             <state key="normal" image="icBack48"/>
                             <connections>
@@ -62,11 +62,11 @@
                         <constraint firstItem="ym3-5Q-qVu" firstAttribute="leading" secondItem="mFd-jy-tVf" secondAttribute="leading" constant="1" id="4U8-8Y-EU8"/>
                         <constraint firstAttribute="bottom" secondItem="HDr-YN-wJC" secondAttribute="bottom" constant="21" id="7U9-r9-FJY"/>
                         <constraint firstItem="ym3-5Q-qVu" firstAttribute="centerY" secondItem="HDr-YN-wJC" secondAttribute="centerY" id="Kbr-IC-bTk"/>
-                        <constraint firstAttribute="height" constant="102" id="ogu-Qy-6Ja"/>
+                        <constraint firstAttribute="height" constant="70" id="ogu-Qy-6Ja"/>
                     </constraints>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fcf-fc-fjJ">
-                    <rect key="frame" x="20" y="124" width="374" height="55.5"/>
+                    <rect key="frame" x="20" y="136" width="374" height="55.5"/>
                     <string key="text">소복소복에서 사용할
 닉네임을 입력해 주세요</string>
                     <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="23"/>
@@ -74,13 +74,13 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="닉네임" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TBZ-0Z-cZ3">
-                    <rect key="frame" x="20" y="223.5" width="374" height="18.5"/>
+                    <rect key="frame" x="20" y="235.5" width="374" height="18.5"/>
                     <fontDescription key="fontDescription" name="Pretendard-SemiBold" family="Pretendard" pointSize="15"/>
                     <color key="textColor" name="gray800_sub"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4t0-cf-gZv" userLabel="닉네임뷰">
-                    <rect key="frame" x="20" y="250" width="374" height="52"/>
+                    <rect key="frame" x="20" y="262" width="374" height="52"/>
                     <subviews>
                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="소보기" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="LiK-iX-PYE">
                             <rect key="frame" x="15" y="15" width="344" height="22"/>
@@ -99,7 +99,7 @@
                     </constraints>
                 </view>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lkl-cX-QCB">
-                    <rect key="frame" x="334" y="320" width="52" height="31"/>
+                    <rect key="frame" x="334" y="332" width="52" height="31"/>
                     <fontDescription key="fontDescription" name="Pretendard-SemiBold" family="Pretendard" pointSize="15"/>
                     <color key="tintColor" name="dark_mint_main"/>
                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -116,7 +116,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2~10자리의 한글, 영문, 숫자만 사용 가능해요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ld6-tD-bOJ">
-                    <rect key="frame" x="30" y="305" width="232" height="16"/>
+                    <rect key="frame" x="30" y="317" width="232" height="16"/>
                     <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="13"/>
                     <color key="textColor" name="pill_color_red"/>
                     <nil key="highlightedColor"/>
@@ -143,7 +143,7 @@
                     </connections>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ePI-CH-nAs" userLabel="밑줄">
-                    <rect key="frame" x="334" y="351" width="52" height="1"/>
+                    <rect key="frame" x="334" y="363" width="52" height="1"/>
                     <color key="backgroundColor" name="gray500_sub"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="E12-nk-9X8"/>
@@ -160,7 +160,7 @@
                 <constraint firstItem="mFd-jy-tVf" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="A5Q-cq-CAc"/>
                 <constraint firstItem="4t0-cf-gZv" firstAttribute="top" secondItem="TBZ-0Z-cZ3" secondAttribute="bottom" constant="8" id="AUe-W1-Whi"/>
                 <constraint firstItem="Lkl-cX-QCB" firstAttribute="top" secondItem="4t0-cf-gZv" secondAttribute="bottom" constant="18" id="FW6-Zu-u3v"/>
-                <constraint firstItem="mFd-jy-tVf" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="Iwy-2A-C53"/>
+                <constraint firstItem="mFd-jy-tVf" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Iwy-2A-C53"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Lkl-cX-QCB" secondAttribute="trailing" constant="28" id="JKY-K4-FOJ"/>
                 <constraint firstItem="ePI-CH-nAs" firstAttribute="top" secondItem="Lkl-cX-QCB" secondAttribute="bottom" id="P7N-6D-ZLo"/>
                 <constraint firstItem="Fcf-fc-fjJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="S1O-rX-tAf"/>

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -17,7 +17,12 @@ final class SignUpViewController: BaseViewController {
     
     // MARK: @IBOutlet Properties
     @IBOutlet weak var titleTextLabel: UILabel!
-    @IBOutlet weak var confirmButton: UIButton!
+    @IBOutlet weak var confirmButton: UIButton!{
+        didSet {
+            confirmButton.backgroundColor = confirmButton.isEnabled ? Color.mint : Color.gray200
+            confirmButton.tintColor = confirmButton.isEnabled ? Color.white : Color.gray500
+        }
+    }
     // 텍스트필드
     @IBOutlet weak var emailTextField: UITextField!
     @IBOutlet weak var emailTextFieldView: UIView!
@@ -112,7 +117,7 @@ final class SignUpViewController: BaseViewController {
         rePasswordTextFieldView.layer.borderColor = isRePasswordRight || !rePasswordTextField.hasText ? Color.gray300.cgColor : Color.pillColorRed.cgColor
     }
     @objc private func inactivatePasswordTextField() {
-        passwordTextFieldView.layer.borderColor = isPasswordRight ? Color.gray300.cgColor : Color.pillColorRed.cgColor
+        passwordTextFieldView.layer.borderColor = isPasswordRight || !passwordTextField.hasText ? Color.gray300.cgColor : Color.pillColorRed.cgColor
     }
     
     // 비밀번호 확인 텍필 값 바뀔 떄
@@ -122,7 +127,7 @@ final class SignUpViewController: BaseViewController {
         rePasswordTextFieldView.layer.borderColor = isRePasswordRight || !rePasswordTextField.hasText ? Color.gray600.cgColor : Color.pillColorRed.cgColor
     }
     @objc private func inactivateRepasswordTextField() {
-        rePasswordTextFieldView.layer.borderColor = isRePasswordRight ? Color.gray300.cgColor : Color.pillColorRed.cgColor
+        rePasswordTextFieldView.layer.borderColor = isRePasswordRight || !rePasswordTextField.hasText ? Color.gray300.cgColor : Color.pillColorRed.cgColor
     }
     
     // 버튼 활성화

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -64,7 +64,8 @@ final class SignUpViewController: BaseViewController {
         rePasswordTextField.addTarget(self, action: #selector(self.inactivateRepasswordTextField), for: .editingDidEnd)
         
         // 버튼 활성화 조건
-        [emailTextField, passwordTextField, rePasswordTextField].forEach {$0.addTarget(self, action: #selector(self.activateOkayButton(_:)), for: .editingChanged)}
+        [passwordTextField, rePasswordTextField].forEach {$0.addTarget(self, action: #selector(self.activateOkayButton), for: .editingChanged)}
+        emailTextField.addTarget(self, action: #selector(self.activateOkayButton), for: .editingDidEnd)
     }
 
     // 정규식 체크
@@ -125,12 +126,12 @@ final class SignUpViewController: BaseViewController {
     }
     
     // 버튼 활성화
-    @objc func activateOkayButton(_ : UIButton) {
+    @objc func activateOkayButton() {
         confirmButton.isEnabled = isEmailRight && isPasswordRight && isRePasswordRight
     }
     
     // MARK: - @IBAction Properties
-    @IBAction func touchUpToPopToSIgnInVIew(_ sender: Any) {
+    @IBAction func touchUpToPopToSIgnInVIew(_ sender: UIButton) {
         navigationController?.popViewController(animated: true)
     }
     

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
@@ -39,29 +39,29 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가입하실 이메일과 비밀번호를 입력해주세요" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dgS-YB-bvH">
-                    <rect key="frame" x="20" y="124" width="374" height="55.5"/>
+                    <rect key="frame" x="20" y="136" width="388" height="55.333333333333343"/>
                     <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="23"/>
                     <color key="textColor" name="gray800_sub"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cZc-Nb-vxf" userLabel="이메일 스택">
-                    <rect key="frame" x="20" y="223.5" width="374" height="106.5"/>
+                    <rect key="frame" x="20" y="235.33333333333334" width="388" height="106.33333333333334"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이메일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2fa-uJ-6ls">
-                            <rect key="frame" x="0.0" y="0.0" width="39" height="18.5"/>
+                            <rect key="frame" x="0.0" y="0.0" width="39" height="18.333333333333332"/>
                             <fontDescription key="fontDescription" name="Pretendard-SemiBold" family="Pretendard" pointSize="15"/>
                             <color key="textColor" name="gray800_sub"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iaH-VC-WqO" userLabel="이메일텍스트필드">
-                            <rect key="frame" x="0.0" y="26.5" width="374" height="54"/>
+                            <rect key="frame" x="0.0" y="26.333333333333343" width="388" height="54"/>
                             <subviews>
                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="soboksobok@gmail.com" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Bdf-4X-ikb" userLabel="이메일">
-                                    <rect key="frame" x="15" y="15" width="344" height="24"/>
+                                    <rect key="frame" x="15" y="15" width="358" height="24"/>
                                     <color key="textColor" name="gray900_sub"/>
                                     <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="18"/>
                                     <textInputTraits key="textInputTraits"/>
@@ -77,7 +77,7 @@
                             </constraints>
                         </view>
                         <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="itb-y6-TcY" userLabel="이메일 형식이 올바르지 않아요">
-                            <rect key="frame" x="0.0" y="88.5" width="166" height="18"/>
+                            <rect key="frame" x="0.0" y="88.333333333333343" width="165.66666666666666" height="18"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wvl-vc-6wj">
                                     <rect key="frame" x="0.0" y="0.0" width="10" height="18"/>
@@ -88,7 +88,7 @@
                                     </constraints>
                                 </view>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이메일 형식이 올바르지 않아요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ejO-1n-ptE">
-                                    <rect key="frame" x="10" y="0.0" width="156" height="16"/>
+                                    <rect key="frame" x="10" y="0.0" width="155.66666666666666" height="15.666666666666666"/>
                                     <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="13"/>
                                     <color key="textColor" name="pill_color_red"/>
                                     <color key="highlightedColor" name="black_sub"/>
@@ -101,19 +101,19 @@
                     </constraints>
                 </stackView>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ljr-Y9-NfJ" userLabel="비밀번호 스택">
-                    <rect key="frame" x="20" y="358" width="374" height="106.5"/>
+                    <rect key="frame" x="20" y="369.66666666666669" width="388" height="106.33333333333331"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="비밀번호" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AM7-lP-LjL">
-                            <rect key="frame" x="0.0" y="0.0" width="52" height="18.5"/>
+                            <rect key="frame" x="0.0" y="0.0" width="52" height="18.333333333333332"/>
                             <fontDescription key="fontDescription" name="Pretendard-SemiBold" family="Pretendard" pointSize="15"/>
                             <color key="textColor" name="gray800_sub"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8wN-5t-vpk" userLabel="비밀번호텍스트필드">
-                            <rect key="frame" x="0.0" y="26.5" width="374" height="54"/>
+                            <rect key="frame" x="0.0" y="26.333333333333314" width="388" height="54"/>
                             <subviews>
                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="8~16자의 영문, 숫자, 특수문자" textAlignment="natural" clearsOnBeginEditing="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="LU6-Xm-bpc" userLabel="비밀번호">
-                                    <rect key="frame" x="15" y="15" width="344" height="24"/>
+                                    <rect key="frame" x="15" y="15" width="358" height="24"/>
                                     <color key="textColor" name="gray900_sub"/>
                                     <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="18"/>
                                     <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
@@ -129,7 +129,7 @@
                             </constraints>
                         </view>
                         <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="Ydh-UF-cgO" userLabel="비밀번호형식은어쩌구">
-                            <rect key="frame" x="0.0" y="88.5" width="265" height="18"/>
+                            <rect key="frame" x="0.0" y="88.333333333333314" width="265" height="18"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SMR-9y-tVj">
                                     <rect key="frame" x="0.0" y="0.0" width="10" height="18"/>
@@ -140,7 +140,7 @@
                                     </constraints>
                                 </view>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8~16자리의 영문, 숫자, 특수문자만 사용 가능해요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FId-4b-I2F" userLabel="비밀번호형식은어쩌구">
-                                    <rect key="frame" x="10" y="0.0" width="255" height="16"/>
+                                    <rect key="frame" x="10" y="0.0" width="255" height="15.666666666666666"/>
                                     <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="13"/>
                                     <color key="textColor" name="pill_color_red"/>
                                     <nil key="highlightedColor"/>
@@ -153,7 +153,7 @@
                     </constraints>
                 </stackView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3jM-k7-QOd">
-                    <rect key="frame" x="20" y="788" width="374" height="52"/>
+                    <rect key="frame" x="20" y="818" width="388" height="52"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="52" id="9Z4-9z-M1A"/>
                     </constraints>
@@ -172,16 +172,16 @@
                     </connections>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aqP-6I-PC5">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="102"/>
+                    <rect key="frame" x="0.0" y="44" width="428" height="70"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="회원가입" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ui1-is-e7G">
-                            <rect key="frame" x="77" y="60.5" width="260" height="20.5"/>
+                            <rect key="frame" x="77" y="28.333333333333329" width="274" height="20.666666666666671"/>
                             <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="17"/>
                             <color key="textColor" name="gray900_sub"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1ff-vb-hST">
-                            <rect key="frame" x="1" y="47" width="48" height="48"/>
+                            <rect key="frame" x="1" y="14.666666666666664" width="48" height="48"/>
                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                             <state key="normal" image="icBack48"/>
                             <connections>
@@ -194,25 +194,25 @@
                         <constraint firstItem="ui1-is-e7G" firstAttribute="leading" secondItem="aqP-6I-PC5" secondAttribute="leading" constant="77" id="Ccu-co-FQw"/>
                         <constraint firstAttribute="trailing" secondItem="ui1-is-e7G" secondAttribute="trailing" constant="77" id="FtX-wF-dau"/>
                         <constraint firstItem="1ff-vb-hST" firstAttribute="centerY" secondItem="ui1-is-e7G" secondAttribute="centerY" id="RFj-jS-DUA"/>
-                        <constraint firstAttribute="height" constant="102" id="hKv-GL-OjV"/>
+                        <constraint firstAttribute="height" constant="70" id="hKv-GL-OjV"/>
                         <constraint firstItem="1ff-vb-hST" firstAttribute="leading" secondItem="aqP-6I-PC5" secondAttribute="leading" constant="1" id="pFZ-Vi-SQR"/>
                         <constraint firstAttribute="bottom" secondItem="ui1-is-e7G" secondAttribute="bottom" constant="21" id="pS9-6m-fmQ"/>
                     </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="KeA-dZ-aEK" userLabel="비밀번호 재입력 스택">
-                    <rect key="frame" x="20" y="492.5" width="374" height="106.5"/>
+                    <rect key="frame" x="20" y="503.99999999999994" width="388" height="106.33333333333331"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="비밀번호 확인" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ghb-8j-XvT">
-                            <rect key="frame" x="0.0" y="0.0" width="81.5" height="18.5"/>
+                            <rect key="frame" x="0.0" y="0.0" width="81.666666666666671" height="18.333333333333332"/>
                             <fontDescription key="fontDescription" name="Pretendard-SemiBold" family="Pretendard" pointSize="15"/>
                             <color key="textColor" name="gray800_sub"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dcb-J4-rZh" userLabel="비밀번호재입력 텍스트필드">
-                            <rect key="frame" x="0.0" y="26.5" width="374" height="54"/>
+                            <rect key="frame" x="0.0" y="26.333333333333371" width="388" height="54"/>
                             <subviews>
                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="비밀번호를 한번 더 입력해 주세요" textAlignment="natural" clearsOnBeginEditing="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="fO5-Vf-KYD" userLabel="비밀번호 재입력">
-                                    <rect key="frame" x="15" y="15" width="344" height="24"/>
+                                    <rect key="frame" x="15" y="15" width="358" height="24"/>
                                     <color key="textColor" name="gray900_sub"/>
                                     <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="18"/>
                                     <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
@@ -228,7 +228,7 @@
                             </constraints>
                         </view>
                         <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="2ez-ye-BIa" userLabel="비밀번호가 일치하지 않아요">
-                            <rect key="frame" x="0.0" y="88.5" width="151.5" height="18"/>
+                            <rect key="frame" x="0.0" y="88.333333333333371" width="151.33333333333334" height="18"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4B5-U1-z4f">
                                     <rect key="frame" x="0.0" y="0.0" width="10" height="18"/>
@@ -239,7 +239,7 @@
                                     </constraints>
                                 </view>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="비밀번호가 일치하지 않아요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iID-Dt-Gg1">
-                                    <rect key="frame" x="10" y="0.0" width="141.5" height="16"/>
+                                    <rect key="frame" x="10" y="0.0" width="141.33333333333334" height="15.666666666666666"/>
                                     <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="13"/>
                                     <color key="textColor" name="pill_color_red"/>
                                     <nil key="highlightedColor"/>
@@ -257,7 +257,7 @@
             <constraints>
                 <constraint firstItem="aqP-6I-PC5" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="0aW-U9-Sq8"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="cZc-Nb-vxf" secondAttribute="trailing" constant="20" id="0tI-DP-5u5"/>
-                <constraint firstItem="aqP-6I-PC5" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="4sC-qk-NDD"/>
+                <constraint firstItem="aqP-6I-PC5" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="4sC-qk-NDD"/>
                 <constraint firstItem="ljr-Y9-NfJ" firstAttribute="top" secondItem="cZc-Nb-vxf" secondAttribute="bottom" constant="28" id="5aX-3N-KfP"/>
                 <constraint firstItem="dgS-YB-bvH" firstAttribute="top" secondItem="aqP-6I-PC5" secondAttribute="bottom" constant="22" id="5ha-ix-qnM"/>
                 <constraint firstItem="ljr-Y9-NfJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="AYk-Bz-xUt"/>
@@ -274,7 +274,7 @@
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="3jM-k7-QOd" secondAttribute="bottom" constant="22" id="r6Y-QA-y6K"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="3jM-k7-QOd" secondAttribute="trailing" constant="20" id="vrd-VZ-Msm"/>
             </constraints>
-            <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+            <nil key="simulatedTopBarMetrics"/>
             <point key="canvasLocation" x="131.8840579710145" y="90.401785714285708"/>
         </view>
     </objects>


### PR DESCRIPTION
## 🌴 PR 요약

SE 를 포함한 일부 기기에서 회원가입 뷰의 아래쪽 내용들이 보이지 않는 이슈가 생겼습니다.

🌱 작업한 브랜치

- feature/#138

🌱 작업한 내용

- 네비게이션 바의 height 를 줄이고 safeArea 영역을 기준으로 위치하도록 변경
- 닉네임 뷰 디자인 QA 반영
- 회원가입뷰 오류 수정

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | 파일첨부바람 |

## 📮 관련 이슈

- Resolved: #138
