### PR TITLE
[#142] 로그인/회원가입 플로우 화면전환 구현

### DIFF
--- a/SobokSobok/SobokSobok/Application/SceneDelegate.swift
+++ b/SobokSobok/SobokSobok/Application/SceneDelegate.swift
@@ -15,8 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         
-        let sampleViewController = TabBarController.instanceFromNib()
-        window?.rootViewController = sampleViewController
+        window?.rootViewController = UINavigationController(rootViewController: SignInViewController.instanceFromNib())
         window?.makeKeyAndVisible()
     }
 }

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/Sign.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/Sign.swift
@@ -15,9 +15,13 @@ struct SignUpResult: Codable {
 
 // MARK: - User
 struct User: Codable {
-    let id: Int
-    let username, email, idFirebase, createdAt: String
-    let updatedAt: String
+    let id: Int?
+    let username: String?
+    let email: String?
+    let idFirebase: String?
+    let accessToken: String?
+    let createdAt: String?
+    let updatedAt: String?
 }
 
 // MARK: - CheckUsernameResult

--- a/SobokSobok/SobokSobok/Presentation/Account/SaveNicknameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Account/SaveNicknameViewController.swift
@@ -151,8 +151,8 @@ extension SaveNicknameViewController {
         AddAccountAPI.shared.saveNickname(memberId: memberID, memberName: savedName, completion: {(result) in
             switch result {
             case .success(let data):
-                print(data)
-            case .requestErr(_):
+                self.dismiss(animated: true)
+            case .requestErr:
                 self.showToast(message: "이미 추가된 사람이에요")
             case .pathErr:
                 print(".pathErr")

--- a/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.swift
@@ -84,12 +84,12 @@ extension SearchNicknameViewController {
         AddAccountAPI.shared.searchNickname(username: username, completion: {(result) in
             switch result {
             case .success(let data):
+                print(data)
                 guard let data = data as? [SearchNicknameData] else { return }
                 if data.isEmpty {
                     self.setNoSearchResult()
                 } else {
                     self.setYesSearchResult()
-                    
                     // 데이터 전달 (다음 뷰에서 사용하기 위함)
                     SearchedUser.shared.searchedUserId = data[0].memberId
                     SearchedUser.shared.searchedUsername = data[0].memberName

--- a/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Account/SearchNicknameViewController.swift
@@ -78,13 +78,10 @@ extension SearchNicknameViewController: UITextFieldDelegate {
 
 extension SearchNicknameViewController {
     func searchNickname() {
-        guard let username = searchNicknameTextField.text else {
-                   return
-        }
+        guard let username = searchNicknameTextField.text else { return }
         AddAccountAPI.shared.searchNickname(username: username, completion: {(result) in
             switch result {
             case .success(let data):
-                print(data)
                 guard let data = data as? [SearchNicknameData] else { return }
                 if data.isEmpty {
                     self.setNoSearchResult()

--- a/SobokSobok/SobokSobok/Presentation/EditFriendName/EditFriendNameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/EditFriendName/EditFriendNameViewController.swift
@@ -95,12 +95,13 @@ final class EditFriendNameViewController: BaseViewController {
     
     // MARK: - @IBAction Properties
     @IBAction func touchUpToConfirm(_ sender: Any) {
-        EditFriend.shared.groupId = 31 //화면 연결되면 전달 받아야함
+        EditFriend.shared.groupId = 31 // 화면 연결되면 전달 받아야함
         EditFriend.shared.memberName = nameTextField.text ?? ""
         editFriendName()
     }
     
     @IBAction func touchUpToDIsmiss(_ sender: Any) {
+        dismiss(animated: true)
     }
     
 }
@@ -112,8 +113,8 @@ extension EditFriendNameViewController {
         
         ShareAPI.shared.editFriendUsername(groupId: groupId, memberName: memberName, completion: {(result) in
             switch result {
-            case .success(let data):
-                print(data)
+            case .success:
+                self.dismiss(animated: true)
             case .requestErr(let message):
                 print("requestErr", message)
             case .pathErr:

--- a/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.xib
+++ b/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/SobokSobok/SobokSobok/Presentation/SignIn/SignInViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignIn/SignInViewController.swift
@@ -9,6 +9,9 @@ import UIKit
 
 final class SignInViewController: BaseViewController {
     
+    // MARK: - Properties
+    private let userDefaults = UserDefaults.standard
+
     // MARK: - @IBOutlet Properties
     @IBOutlet weak var titleTextLabel: UILabel!
     @IBOutlet weak var emailTextField: UITextField!
@@ -95,8 +98,14 @@ extension SignInViewController {
         guard let password = passwordTextField.text else { return }
         SignAPI.shared.signIn(email: email, password: password, completion: {(result) in
             switch result {
-            case .success:
-                self.showToast(message: "로그인 성공 : \(email), \(password)")
+            case .success(let data):
+                guard let data = data as? User else { return }
+                // 데이터 전달
+                self.userDefaults.set(data.username, forKey: "username")
+                self.userDefaults.set(data.accessToken, forKey: "accessToken")
+                print("\(data.username),\(data.accessToken)")
+                // 화면 이동
+                self.navigationController?.pushViewController(TabBarController.instanceFromNib(), animated: true)
             case .requestErr:
                 self.showToast(message: "이메일 또는 비밀번호를 다시 확인해주세요")
             case .pathErr:

--- a/SobokSobok/SobokSobok/Presentation/SignUp/CompleteSignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/CompleteSignUpViewController.swift
@@ -9,16 +9,19 @@ import UIKit
 
 final class CompleteSignUpViewController: BaseViewController {
 
+    // MARK: - Properties
+
+    // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-    
     override func style() {
         navigationController?.navigationBar.isHidden = true
     }
     
+    // MARK: - @IBAction Properties
     @IBAction func touchUpToStart(_ sender: UIButton) {
-        print("로그인")
+        // 메인뷰로 화면 이동
+        navigationController?.pushViewController(TabBarController.instanceFromNib(), animated: true)
     }
-    
 }

--- a/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/SignUpViewController.swift
@@ -17,12 +17,7 @@ final class SignUpViewController: BaseViewController {
     
     // MARK: @IBOutlet Properties
     @IBOutlet weak var titleTextLabel: UILabel!
-    @IBOutlet weak var confirmButton: UIButton!{
-        didSet {
-            confirmButton.backgroundColor = confirmButton.isEnabled ? Color.mint : Color.gray200
-            confirmButton.tintColor = confirmButton.isEnabled ? Color.white : Color.gray500
-        }
-    }
+    @IBOutlet weak var confirmButton: UIButton!
     // 텍스트필드
     @IBOutlet weak var emailTextField: UITextField!
     @IBOutlet weak var emailTextFieldView: UIView!

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Sign/SignAPI.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Sign/SignAPI.swift
@@ -21,7 +21,7 @@ public class SignAPI {
             case .success(let response):
                 let statusCode = response.statusCode
                 let data = response.data
-                let networkResult = self.judgeStatus(by: statusCode, data, [User].self)
+                let networkResult = self.judgeStatus(by: statusCode, data, User.self)
                 completion(networkResult)
             case .failure(let err):
                 print(err)

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Sign/SignAPI.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Sign/SignAPI.swift
@@ -35,7 +35,7 @@ public class SignAPI {
             case .success(let response):
                 let statusCode = response.statusCode
                 let data = response.data
-                let networkResult = self.judgeStatus(by: statusCode, data, [SignUpResult].self)
+                let networkResult = self.judgeStatus(by: statusCode, data, SignUpResult.self)
                 completion(networkResult)
             case .failure(let err):
                 print(err)


### PR DESCRIPTION
## 🌴 PR 요약

로그인에서 메인화면으로 가는 화면 전환을 구현했습니다.

🌱 작업한 브랜치

- feature/#142

🌱 작업한 내용

- 첫 화면 로그인 뷰로 저장
- 로그인 -> 메인화면 전환
- 회원가입 -> 메인화면 전환 구현
- 엑세스 토큰 및 유저네임 UserDefaults에 저장
- 친구 이름 수정 뷰 화면전환 구현 (연결 안함)
- 친구 이름 저장 뷰 화면전환 구현

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | 파일첨부바람 |

## 📮 관련 이슈

- Resolved: #142
