### PR TITLE
[#239] 공유 탭 API 연결

### DIFF
--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		BDDAA5AB2789BCD3000C0AF8 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA5A52789BCD3000C0AF8 /* Image.swift */; };
 		BDDAA5AD2789BCD3000C0AF8 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA5A72789BCD3000C0AF8 /* Color.swift */; };
 		BDDAA5AE2789BCD3000C0AF8 /* Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA5A82789BCD3000C0AF8 /* Text.swift */; };
+		BDDF7691289951C20096196B /* ShareViewController+Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDF7690289951C20096196B /* ShareViewController+Network.swift */; };
 		BDE2ADE42891266200A42559 /* ShareTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE2ADE32891266200A42559 /* ShareTopView.swift */; };
 		BDFE75DE278786AE00014BE1 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = BDFE75DD278786AE00014BE1 /* Then */; };
 		EC0213EC27CE665B00CF3569 /* AddPillFirstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0213EB27CE665B00CF3569 /* AddPillFirstView.swift */; };
@@ -342,6 +343,7 @@
 		BDDAA5A52789BCD3000C0AF8 /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		BDDAA5A72789BCD3000C0AF8 /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		BDDAA5A82789BCD3000C0AF8 /* Text.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Text.swift; sourceTree = "<group>"; };
+		BDDF7690289951C20096196B /* ShareViewController+Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShareViewController+Network.swift"; sourceTree = "<group>"; };
 		BDE2ADE32891266200A42559 /* ShareTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTopView.swift; sourceTree = "<group>"; };
 		EC0213EB27CE665B00CF3569 /* AddPillFirstView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPillFirstView.swift; sourceTree = "<group>"; };
 		EC0213ED27CE669B00CF3569 /* NavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationView.swift; sourceTree = "<group>"; };
@@ -883,6 +885,7 @@
 			children = (
 				BDE2ADE22891265500A42559 /* Views */,
 				BD14F362278EB4B000F316AF /* ShareViewController.swift */,
+				BDDF7690289951C20096196B /* ShareViewController+Network.swift */,
 				F6494F2F2795AECC00F43A94 /* SendStickerPopUpViewController.swift */,
 				F6494F302795AECC00F43A94 /* SendStickerPopUpViewController.xib */,
 			);
@@ -1887,6 +1890,7 @@
 				9AB833F4288972440040FC2A /* SettingViewController.swift in Sources */,
 				BD71210327977DBC0068B981 /* PillManagementService.swift in Sources */,
 				BD14F364278EB4B000F316AF /* ShareViewController.swift in Sources */,
+				BDDF7691289951C20096196B /* ShareViewController+Network.swift in Sources */,
 				BD4611C328608389007BEE87 /* CalendarTopView.swift in Sources */,
 				BD51AE3C2790BF1500314A94 /* StickerCollectionViewCell.swift in Sources */,
 				BD515E39278770C5003BD5A4 /* AppDelegate.swift in Sources */,

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/Home/Pill.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/Home/Pill.swift
@@ -12,13 +12,18 @@ struct PillList: Codable {
     let scheduleList: [Pill]?
 }
 
+/*
+ TODO: [수정 요청 하기]
+ - 멤버 stickerId는 배열
+ - 내 stickerId는 딕셔너리
+ */
 struct Pill: Codable {
     let scheduleId: Int
     let pillId: Int
     let pillName: String
     let isCheck: Bool
     let color: String
-    let stickerId: [String: Int]
+//    let stickerId: [String: Int]?
     let stickerTotalCount: Int
     let isLikedSchedule: Bool?
 }

--- a/SobokSobok/SobokSobok/Network/API/ScheduleEndPoint.swift
+++ b/SobokSobok/SobokSobok/Network/API/ScheduleEndPoint.swift
@@ -12,6 +12,7 @@ enum ScheduleEndPoint {
     case getPillList(date: String)
     case checkPillSchedule(scheduleId: Int)
     case uncheckPillSchedule(scheduleId: Int)
+    case getGroupInformation
 }
 
 extension ScheduleEndPoint: EndPoint {
@@ -23,6 +24,8 @@ extension ScheduleEndPoint: EndPoint {
             return .GET
         case .checkPillSchedule, .uncheckPillSchedule:
             return .PUT
+        case .getGroupInformation:
+            return .GET
         }
     }
     
@@ -33,6 +36,8 @@ extension ScheduleEndPoint: EndPoint {
         case .getPillList:
             return nil
         case .checkPillSchedule, .uncheckPillSchedule:
+            return nil
+        case .getGroupInformation:
             return nil
         }
     }
@@ -48,6 +53,8 @@ extension ScheduleEndPoint: EndPoint {
             return "\(baseURL)/schedule/check/\(scheduleId)"
         case .uncheckPillSchedule(let scheduleId):
             return "\(baseURL)/schedule/uncheck/\(scheduleId)"
+        case .getGroupInformation:
+            return "\(baseURL)/group"
         }
     }
 }

--- a/SobokSobok/SobokSobok/Network/API/ScheduleEndPoint.swift
+++ b/SobokSobok/SobokSobok/Network/API/ScheduleEndPoint.swift
@@ -14,6 +14,7 @@ enum ScheduleEndPoint {
     case uncheckPillSchedule(scheduleId: Int)
     case getGroupInformation
     case getMemberSchedule(memberId: Int, date: String)
+    case getMemberPillList(memberId: Int, date: String)
 }
 
 extension ScheduleEndPoint: EndPoint {
@@ -29,6 +30,8 @@ extension ScheduleEndPoint: EndPoint {
             return .GET
         case .getMemberSchedule:
             return .GET
+        case .getMemberPillList:
+            return .GET
         }
     }
     
@@ -43,6 +46,8 @@ extension ScheduleEndPoint: EndPoint {
         case .getGroupInformation:
             return nil
         case .getMemberSchedule:
+            return nil
+        case .getMemberPillList:
             return nil
         }
     }
@@ -62,6 +67,8 @@ extension ScheduleEndPoint: EndPoint {
             return "\(baseURL)/group"
         case .getMemberSchedule(let memberId, let date):
             return "\(baseURL)/schedule/\(memberId)/calendar?date=\(date)"
+        case .getMemberPillList(let memberId, let date):
+            return "\(baseURL)/schedule/\(memberId)/detail?date=\(date)"
         }
     }
 }

--- a/SobokSobok/SobokSobok/Network/API/ScheduleEndPoint.swift
+++ b/SobokSobok/SobokSobok/Network/API/ScheduleEndPoint.swift
@@ -13,6 +13,7 @@ enum ScheduleEndPoint {
     case checkPillSchedule(scheduleId: Int)
     case uncheckPillSchedule(scheduleId: Int)
     case getGroupInformation
+    case getMemberSchedule(memberId: Int, date: String)
 }
 
 extension ScheduleEndPoint: EndPoint {
@@ -26,6 +27,8 @@ extension ScheduleEndPoint: EndPoint {
             return .PUT
         case .getGroupInformation:
             return .GET
+        case .getMemberSchedule:
+            return .GET
         }
     }
     
@@ -38,6 +41,8 @@ extension ScheduleEndPoint: EndPoint {
         case .checkPillSchedule, .uncheckPillSchedule:
             return nil
         case .getGroupInformation:
+            return nil
+        case .getMemberSchedule:
             return nil
         }
     }
@@ -55,6 +60,8 @@ extension ScheduleEndPoint: EndPoint {
             return "\(baseURL)/schedule/uncheck/\(scheduleId)"
         case .getGroupInformation:
             return "\(baseURL)/group"
+        case .getMemberSchedule(let memberId, let date):
+            return "\(baseURL)/schedule/\(memberId)/calendar?date=\(date)"
         }
     }
 }

--- a/SobokSobok/SobokSobok/Network/Service/ScheduleManager.swift
+++ b/SobokSobok/SobokSobok/Network/Service/ScheduleManager.swift
@@ -13,6 +13,7 @@ protocol ScheduleServiceable {
     func checkPillSchedule(for scheduleId: Int) async throws -> PillDetail?
     func uncheckPillSchedule(for scheduleId: Int) async throws -> PillDetail?
     func getGroupInformation() async throws -> [Member]?
+    func getMemberSchedule(memberId: Int, date: String) async throws -> [Schedule]?
 }
 
 struct ScheduleManager: ScheduleServiceable {
@@ -55,6 +56,13 @@ struct ScheduleManager: ScheduleServiceable {
     func getGroupInformation() async throws -> [Member]? {
         let request = ScheduleEndPoint
             .getGroupInformation
+            .createRequest(environment: environment)
+        return try await self.apiService.request(request)
+    }
+    
+    func getMemberSchedule(memberId: Int, date: String) async throws -> [Schedule]? {
+        let request = ScheduleEndPoint
+            .getMemberSchedule(memberId: memberId, date: date)
             .createRequest(environment: environment)
         return try await self.apiService.request(request)
     }

--- a/SobokSobok/SobokSobok/Network/Service/ScheduleManager.swift
+++ b/SobokSobok/SobokSobok/Network/Service/ScheduleManager.swift
@@ -14,6 +14,7 @@ protocol ScheduleServiceable {
     func uncheckPillSchedule(for scheduleId: Int) async throws -> PillDetail?
     func getGroupInformation() async throws -> [Member]?
     func getMemberSchedule(memberId: Int, date: String) async throws -> [Schedule]?
+    func getMemberPillList(memberId: Int, date: String) async throws -> [PillList]?
 }
 
 struct ScheduleManager: ScheduleServiceable {
@@ -63,6 +64,13 @@ struct ScheduleManager: ScheduleServiceable {
     func getMemberSchedule(memberId: Int, date: String) async throws -> [Schedule]? {
         let request = ScheduleEndPoint
             .getMemberSchedule(memberId: memberId, date: date)
+            .createRequest(environment: environment)
+        return try await self.apiService.request(request)
+    }
+    
+    func getMemberPillList(memberId: Int, date: String) async throws -> [PillList]? {
+        let request = ScheduleEndPoint
+            .getMemberPillList(memberId: memberId, date: date)
             .createRequest(environment: environment)
         return try await self.apiService.request(request)
     }

--- a/SobokSobok/SobokSobok/Network/Service/ScheduleManager.swift
+++ b/SobokSobok/SobokSobok/Network/Service/ScheduleManager.swift
@@ -12,6 +12,7 @@ protocol ScheduleServiceable {
     func getPillList(for date: String) async throws -> [PillList]?
     func checkPillSchedule(for scheduleId: Int) async throws -> PillDetail?
     func uncheckPillSchedule(for scheduleId: Int) async throws -> PillDetail?
+    func getGroupInformation() async throws -> [Member]?
 }
 
 struct ScheduleManager: ScheduleServiceable {
@@ -47,6 +48,13 @@ struct ScheduleManager: ScheduleServiceable {
     func uncheckPillSchedule(for scheduleId: Int) async throws -> PillDetail? {
         let request = ScheduleEndPoint
             .uncheckPillSchedule(scheduleId: scheduleId)
+            .createRequest(environment: environment)
+        return try await self.apiService.request(request)
+    }
+    
+    func getGroupInformation() async throws -> [Member]? {
+        let request = ScheduleEndPoint
+            .getGroupInformation
             .createRequest(environment: environment)
         return try await self.apiService.request(request)
     }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
@@ -52,7 +52,15 @@ extension ScheduleViewController {
         Task {
             do {
                 let result = try await scheduleManager.getMemberSchedule(memberId: memberId, date: date)
-                print(11111, result)
+            }
+        }
+    }
+    
+    func getMemberPillLists(memberId: Int, date: String) {
+        Task {
+            do {
+                let result = try await scheduleManager.getMemberPillList(memberId: memberId, date: date)
+                print(22222, result)
             }
         }
     }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
@@ -47,4 +47,13 @@ extension ScheduleViewController {
             }
         }
     }
+    
+    func getMemberSchedules(memberId: Int, date: String) {
+        Task {
+            do {
+                let result = try await scheduleManager.getMemberSchedule(memberId: memberId, date: date)
+                print(11111, result)
+            }
+        }
+    }
 }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
@@ -96,6 +96,7 @@ final class ScheduleViewController: BaseViewController {
         super.viewWillAppear(animated)
         getMySchedules(date: "2022-06-04")
         getMyPillLists(date: "2022-06-22")
+        getMemberSchedules(memberId: 187, date: "2022-06-22")
     }
     
     override func style() {

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
@@ -96,7 +96,8 @@ final class ScheduleViewController: BaseViewController {
         super.viewWillAppear(animated)
         getMySchedules(date: "2022-06-04")
         getMyPillLists(date: "2022-06-22")
-        getMemberSchedules(memberId: 187, date: "2022-06-22")
+//        getMemberSchedules(memberId: 187, date: "2022-06-22")
+        getMemberPillLists(memberId: 187, date: "2022-06-22")
     }
     
     override func style() {

--- a/SobokSobok/SobokSobok/Presentation/Share/ShareViewController+Network.swift
+++ b/SobokSobok/SobokSobok/Presentation/Share/ShareViewController+Network.swift
@@ -1,0 +1,21 @@
+//
+//  ShareViewController+Network.swift
+//  SobokSobok
+//
+//  Created by taekki on 2022/08/02.
+//
+
+extension ShareViewController {
+    func getGroupInformation() {
+        Task {
+            do {
+                let members = try await scheduleManager.getGroupInformation()
+                if let members = members,
+                   !members.isEmpty {
+                    self.members = members
+                    shareTopView.friends = members
+                }
+            }
+        }
+    }
+}

--- a/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.swift
@@ -8,20 +8,17 @@
 import UIKit
 
 final class ShareViewController: BaseViewController {
-    var members: [Member] = [
-        Member(groupId: 12, memberId: 12, memberName: "TAB"),
-        Member(groupId: 12, memberId: 12, memberName: "TAB"),
-        Member(groupId: 12, memberId: 12, memberName: "TAB"),
-    ]
+    var members: [Member] = []
+    lazy var scheduleManager: ScheduleServiceable = ScheduleManager(apiService: APIManager(),
+                                                               environment: .development)
     
-    private lazy var shareTopView = ShareTopView()
+    lazy var shareTopView = ShareTopView()
     private let scheduleViewController = ScheduleViewController()
     private lazy var containerView = UIView()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        getGroupInfo()
-        
+
         view.addSubviews(shareTopView, containerView)
         embed(scheduleViewController, inView: containerView)
         
@@ -42,27 +39,6 @@ final class ShareViewController: BaseViewController {
         super.viewWillAppear(animated)      
 
         tabBarController?.tabBar.isHidden = false
-    }
-}
-
-extension ShareViewController: PagerTabDelegate {
-    func addFriendDeleagte() {
-        let viewController = SearchNicknameViewController.instanceFromNib()
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-}
-
-extension ShareViewController {
-    private func getGroupInfo() {
-        ShareAPI.shared.getGroupInfo { response in
-            switch response {
-            case .success(let data):
-                if let data = data as? [Member] {
-                    self.members = data
-                }
-            default:
-                return
-            }
-        }
+        getGroupInformation()
     }
 }

--- a/SobokSobok/SobokSobok/Presentation/Share/Views/ShareTopView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Share/Views/ShareTopView.swift
@@ -9,7 +9,18 @@ import UIKit
 
 final class ShareTopView: BaseView {
     
-    var friends: [String] = ["태현", "태현", "태현", "태현", "태현"]
+    var friends: [Member] = [] {
+        didSet {
+            updateUI()
+            updateButton()
+        }
+    }
+    
+    var currentIndex: Int = 0 {
+        didSet {
+            updateButton()
+        }
+    }
     
     lazy var friendHStackView = UIStackView().then {
         $0.axis = .horizontal
@@ -23,6 +34,7 @@ final class ShareTopView: BaseView {
         $0.setImage(Image.icPlus48, for: .normal)
         $0.tintColor = Color.white
         $0.addTarget(self, action: #selector(addFriendButtonTapped), for: .touchUpInside)
+        $0.isHidden = friends.isEmpty
     }
     
     override func setupView() {
@@ -43,7 +55,7 @@ final class ShareTopView: BaseView {
         
         addFriendButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(7.adjustedHeight)
-            $0.centerY.equalTo(friendHStackView.snp.centerY)
+            $0.bottom.equalToSuperview().inset(3.adjustedHeight)
         }
     }
 }
@@ -51,17 +63,42 @@ final class ShareTopView: BaseView {
 extension ShareTopView {
     
     private func configureHStackView() {
-        for friend in friends {
+        for index in 0..<5 {
             let button = UIButton()
-            button.setTitle(friend, for: .normal)
-            button.setTitleColor(Color.white, for: .normal)
+            button.tag = index
+            button.setTitleColor(Color.middleMint, for: .normal)
+            button.titleLabel?.font = UIFont.font(.pretendardMedium, ofSize: 17)
             button.addTarget(self, action: #selector(friendNameButtonTapped), for: .touchUpInside)
+            button.isHidden = true
             friendHStackView.addArrangedSubviews(button)
         }
     }
     
-    @objc func friendNameButtonTapped() {
-        print("친구 이름")
+    private func updateUI() {
+        for index in friends.indices {
+            let button = friendHStackView.arrangedSubviews[index] as! UIButton
+            button.isHidden = false
+            button.setTitle(friends[index].memberName, for: .normal)
+        }
+        addFriendButton.isHidden = friends.isEmpty
+    }
+    
+    private func updateButton() {
+        for index in friends.indices {
+            let button = friendHStackView.arrangedSubviews[index] as! UIButton
+            
+            if index == currentIndex {
+                button.setTitleColor(Color.white, for: .normal)
+                button.titleLabel?.font = UIFont.font(.pretendardExtraBold, ofSize: 17)
+            } else {
+                button.setTitleColor(Color.middleMint, for: .normal)
+                button.titleLabel?.font = UIFont.font(.pretendardMedium, ofSize: 17)
+            }
+        }
+    }
+    
+    @objc func friendNameButtonTapped(_ sender: UIButton) {
+        currentIndex = sender.tag
     }
     
     @objc func addFriendButtonTapped() {


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->
공유 탭 API 연결
- 우선 데이터 불러오는 것까지만 확인했습니다.
- UI 연결은 스티커 관련 API(여기까지 하면 API 11/13완료)까지 모두 붙이고 마무리하겠습니다.
- 공유 관련 API 확인하느라 Postman으로 친구 맺고 나름 쉽지 않았음... (Thanks to 승헌...)

🌱 작업한 브랜치

- feature/#239

🌱 작업한 내용

- 그룹 정보 가져오기
- 멤버 캘린더 조회
- 멤버 약 일정 조회

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | - |

## 📮 관련 이슈

- Resolved: #239
