### PR TITLE
[#240] 스티커 관련 API 구현

### DIFF
--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -132,6 +132,8 @@
 		BDDAA5AD2789BCD3000C0AF8 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA5A72789BCD3000C0AF8 /* Color.swift */; };
 		BDDAA5AE2789BCD3000C0AF8 /* Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA5A82789BCD3000C0AF8 /* Text.swift */; };
 		BDDF7691289951C20096196B /* ShareViewController+Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDF7690289951C20096196B /* ShareViewController+Network.swift */; };
+		BDDF7721289A952B0096196B /* StickerEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDF7720289A952B0096196B /* StickerEndPoint.swift */; };
+		BDDF7723289A95340096196B /* StickerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDF7722289A95340096196B /* StickerManager.swift */; };
 		BDE2ADE42891266200A42559 /* ShareTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE2ADE32891266200A42559 /* ShareTopView.swift */; };
 		BDFE75DE278786AE00014BE1 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = BDFE75DD278786AE00014BE1 /* Then */; };
 		EC0213EC27CE665B00CF3569 /* AddPillFirstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0213EB27CE665B00CF3569 /* AddPillFirstView.swift */; };
@@ -344,6 +346,8 @@
 		BDDAA5A72789BCD3000C0AF8 /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		BDDAA5A82789BCD3000C0AF8 /* Text.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Text.swift; sourceTree = "<group>"; };
 		BDDF7690289951C20096196B /* ShareViewController+Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShareViewController+Network.swift"; sourceTree = "<group>"; };
+		BDDF7720289A952B0096196B /* StickerEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerEndPoint.swift; sourceTree = "<group>"; };
+		BDDF7722289A95340096196B /* StickerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerManager.swift; sourceTree = "<group>"; };
 		BDE2ADE32891266200A42559 /* ShareTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTopView.swift; sourceTree = "<group>"; };
 		EC0213EB27CE665B00CF3569 /* AddPillFirstView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPillFirstView.swift; sourceTree = "<group>"; };
 		EC0213ED27CE669B00CF3569 /* NavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationView.swift; sourceTree = "<group>"; };
@@ -563,6 +567,7 @@
 			isa = PBXGroup;
 			children = (
 				BD382F70286DA350002E91F0 /* ScheduleManager.swift */,
+				BDDF7722289A95340096196B /* StickerManager.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -571,6 +576,7 @@
 			isa = PBXGroup;
 			children = (
 				BD382F6C286D9A6B002E91F0 /* ScheduleEndPoint.swift */,
+				BDDF7720289A952B0096196B /* StickerEndPoint.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1837,6 +1843,7 @@
 				9A3DF0B92798250A00D07A8C /* AddAccontAPI.swift in Sources */,
 				EC037612278B2EAF00CA4B54 /* AddMedicineTableViewCell.swift in Sources */,
 				F6EA7457281D919000163B2E /* NavigationBarView.swift in Sources */,
+				BDDF7721289A952B0096196B /* StickerEndPoint.swift in Sources */,
 				9A3DF09227966A3A00D07A8C /* SignAPI.swift in Sources */,
 				F60BAEB7279B3E690012707C /* SplashView.swift in Sources */,
 				EC68A95827982E40002FC0E6 /* AddPillAPI.swift in Sources */,
@@ -1867,6 +1874,7 @@
 				EC91946628224C1A0047893F /* AddPillInfoView.swift in Sources */,
 				EC4BF2ED27C0BA9000B28F90 /* SobokButton.swift in Sources */,
 				BD7120E92796A61A0068B981 /* Schedule.swift in Sources */,
+				BDDF7723289A95340096196B /* StickerManager.swift in Sources */,
 				9A3DF0C62798CE4300D07A8C /* EditFriendNameViewController.swift in Sources */,
 				ECA6379E281D1AF800CA2291 /* AddPillThirdView.swift in Sources */,
 				BD7120FF279777AB0068B981 /* UIViewController+Extension.swift in Sources */,

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/Sticker/Sticker.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/Sticker/Sticker.swift
@@ -19,6 +19,7 @@ struct Stickers: Codable {
 struct Sticker: Codable {
     let id: Int?
     let likeScheduleId: Int?
+    let likescheduleId: Int?
     let scheduleId: Int
     let senderId: Int?
     let stickerId: Int

--- a/SobokSobok/SobokSobok/Network/API/StickerEndPoint.swift
+++ b/SobokSobok/SobokSobok/Network/API/StickerEndPoint.swift
@@ -6,3 +6,31 @@
 //
 
 import Foundation
+
+enum StickerEndPoint {
+    case getStickers(scheduleId: Int)
+}
+
+extension StickerEndPoint: EndPoint {
+    var method: HttpMethod {
+        switch self {
+        case .getStickers:
+            return .GET
+        }
+    }
+    
+    var body: Data? {
+        switch self {
+        case .getStickers:
+            return nil
+        }
+    }
+    
+    func getURL(from environment: APIEnvironment) -> String {
+        let baseURL = environment.baseURL
+        switch self {
+        case .getStickers(let scheduleId):
+            return "\(baseURL)/sticker/\(scheduleId)"
+        }
+    }
+}

--- a/SobokSobok/SobokSobok/Network/API/StickerEndPoint.swift
+++ b/SobokSobok/SobokSobok/Network/API/StickerEndPoint.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum StickerEndPoint {
     case getStickers(scheduleId: Int)
+    case postStickers(scheduleId: Int, stickerId: Int)
 }
 
 extension StickerEndPoint: EndPoint {
@@ -16,12 +17,16 @@ extension StickerEndPoint: EndPoint {
         switch self {
         case .getStickers:
             return .GET
+        case .postStickers:
+            return .POST
         }
     }
     
     var body: Data? {
         switch self {
         case .getStickers:
+            return nil
+        case .postStickers:
             return nil
         }
     }
@@ -31,6 +36,8 @@ extension StickerEndPoint: EndPoint {
         switch self {
         case .getStickers(let scheduleId):
             return "\(baseURL)/sticker/\(scheduleId)"
+        case .postStickers(let scheduleId, let stickerId):
+            return "\(baseURL)/sticker/\(scheduleId)?stickerId=\(stickerId)"
         }
     }
 }

--- a/SobokSobok/SobokSobok/Network/API/StickerEndPoint.swift
+++ b/SobokSobok/SobokSobok/Network/API/StickerEndPoint.swift
@@ -10,6 +10,7 @@ import Foundation
 enum StickerEndPoint {
     case getStickers(scheduleId: Int)
     case postStickers(scheduleId: Int, stickerId: Int)
+    case changeSticker(likeScheduleId: Int, stickerId: Int)
 }
 
 extension StickerEndPoint: EndPoint {
@@ -19,6 +20,8 @@ extension StickerEndPoint: EndPoint {
             return .GET
         case .postStickers:
             return .POST
+        case .changeSticker:
+            return .PUT
         }
     }
     
@@ -27,6 +30,8 @@ extension StickerEndPoint: EndPoint {
         case .getStickers:
             return nil
         case .postStickers:
+            return nil
+        case .changeSticker:
             return nil
         }
     }
@@ -38,6 +43,8 @@ extension StickerEndPoint: EndPoint {
             return "\(baseURL)/sticker/\(scheduleId)"
         case .postStickers(let scheduleId, let stickerId):
             return "\(baseURL)/sticker/\(scheduleId)?stickerId=\(stickerId)"
+        case .changeSticker(let likeScheduleId, let stickerId):
+            return "\(baseURL)/sticker/my/\(likeScheduleId)?stickerId=\(stickerId)"
         }
     }
 }

--- a/SobokSobok/SobokSobok/Network/API/StickerEndPoint.swift
+++ b/SobokSobok/SobokSobok/Network/API/StickerEndPoint.swift
@@ -1,0 +1,8 @@
+//
+//  StickerEndPoint.swift
+//  SobokSobok
+//
+//  Created by taekki on 2022/08/03.
+//
+
+import Foundation

--- a/SobokSobok/SobokSobok/Network/Service/StickerManager.swift
+++ b/SobokSobok/SobokSobok/Network/Service/StickerManager.swift
@@ -6,3 +6,24 @@
 //
 
 import Foundation
+
+protocol StickerServiceable {
+    func getStickers(for scheduleId: Int) async throws -> [Stickers]?
+}
+
+struct StickerManager: StickerServiceable {
+    private let apiService: Requestable
+    private let environment: APIEnvironment
+    
+    init(apiService: Requestable, environment: APIEnvironment) {
+        self.apiService = apiService
+        self.environment = environment
+    }
+    
+    func getStickers(for scheduleId: Int) async throws -> [Stickers]? {
+        let request = StickerEndPoint
+            .getStickers(scheduleId: scheduleId)
+            .createRequest(environment: environment)
+        return try await self.apiService.request(request)
+    }
+}

--- a/SobokSobok/SobokSobok/Network/Service/StickerManager.swift
+++ b/SobokSobok/SobokSobok/Network/Service/StickerManager.swift
@@ -1,0 +1,8 @@
+//
+//  StickerManager.swift
+//  SobokSobok
+//
+//  Created by taekki on 2022/08/03.
+//
+
+import Foundation

--- a/SobokSobok/SobokSobok/Network/Service/StickerManager.swift
+++ b/SobokSobok/SobokSobok/Network/Service/StickerManager.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol StickerServiceable {
     func getStickers(for scheduleId: Int) async throws -> [Stickers]?
     func postStickers(for scheduleId: Int, withSticker stickerId: Int) async throws -> Sticker?
-    func changeSticker(for likeScheduleId: Int, withSticker stickerId: Int) async throws -> Sticker?
+    func changeSticker(for likeScheduleId: Int, withSticker stickerId: Int) async throws -> [Sticker]?
 }
 
 struct StickerManager: StickerServiceable {
@@ -36,7 +36,7 @@ struct StickerManager: StickerServiceable {
         return try await self.apiService.request(request)
     }
     
-    func changeSticker(for likeScheduleId: Int, withSticker stickerId: Int) async throws -> Sticker? {
+    func changeSticker(for likeScheduleId: Int, withSticker stickerId: Int) async throws -> [Sticker]? {
         let request = StickerEndPoint
             .changeSticker(likeScheduleId: likeScheduleId, stickerId: stickerId)
             .createRequest(environment: environment)

--- a/SobokSobok/SobokSobok/Network/Service/StickerManager.swift
+++ b/SobokSobok/SobokSobok/Network/Service/StickerManager.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol StickerServiceable {
     func getStickers(for scheduleId: Int) async throws -> [Stickers]?
     func postStickers(for scheduleId: Int, withSticker stickerId: Int) async throws -> Sticker?
+    func changeSticker(for likeScheduleId: Int, withSticker stickerId: Int) async throws -> Sticker?
 }
 
 struct StickerManager: StickerServiceable {
@@ -31,6 +32,13 @@ struct StickerManager: StickerServiceable {
     func postStickers(for scheduleId: Int, withSticker stickerId: Int) async throws -> Sticker? {
         let request = StickerEndPoint
             .postStickers(scheduleId: scheduleId, stickerId: stickerId)
+            .createRequest(environment: environment)
+        return try await self.apiService.request(request)
+    }
+    
+    func changeSticker(for likeScheduleId: Int, withSticker stickerId: Int) async throws -> Sticker? {
+        let request = StickerEndPoint
+            .changeSticker(likeScheduleId: likeScheduleId, stickerId: stickerId)
             .createRequest(environment: environment)
         return try await self.apiService.request(request)
     }

--- a/SobokSobok/SobokSobok/Network/Service/StickerManager.swift
+++ b/SobokSobok/SobokSobok/Network/Service/StickerManager.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol StickerServiceable {
     func getStickers(for scheduleId: Int) async throws -> [Stickers]?
+    func postStickers(for scheduleId: Int, withSticker stickerId: Int) async throws -> Sticker?
 }
 
 struct StickerManager: StickerServiceable {
@@ -23,6 +24,13 @@ struct StickerManager: StickerServiceable {
     func getStickers(for scheduleId: Int) async throws -> [Stickers]? {
         let request = StickerEndPoint
             .getStickers(scheduleId: scheduleId)
+            .createRequest(environment: environment)
+        return try await self.apiService.request(request)
+    }
+    
+    func postStickers(for scheduleId: Int, withSticker stickerId: Int) async throws -> Sticker? {
+        let request = StickerEndPoint
+            .postStickers(scheduleId: scheduleId, stickerId: stickerId)
             .createRequest(environment: environment)
         return try await self.apiService.request(request)
     }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
@@ -64,4 +64,13 @@ extension ScheduleViewController {
             }
         }
     }
+    
+    func getStickers(for scheduleId: Int) {
+        Task {
+            do {
+                let stickers = try await stickerManageer.getStickers(for: scheduleId)
+                print(33333, stickers)
+            }
+        }
+    }
 }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
@@ -82,4 +82,13 @@ extension ScheduleViewController {
             }
         }
     }
+    
+    func changeSticker(for likeScheduleId: Int, withSticker stickerId: Int) {
+        Task {
+            do {
+                let result = try await stickerManageer.changeSticker(for: likeScheduleId, withSticker: stickerId)
+                print(55555, result)
+            }
+        }
+    }
 }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
@@ -73,4 +73,13 @@ extension ScheduleViewController {
             }
         }
     }
+    
+    func postSticker(for scheduleId: Int, withSticker stickerId: Int) {
+        Task {
+            do {
+                let result = try await stickerManageer.postStickers(for: scheduleId, withSticker: stickerId)
+                print(44444, result)
+            }
+        }
+    }
 }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
@@ -77,6 +77,8 @@ final class ScheduleViewController: BaseViewController {
     
     let scheduleManager: ScheduleServiceable = ScheduleManager(apiService: APIManager(),
                                                                environment: .development)
+    let stickerManageer: StickerServiceable = StickerManager(apiService: APIManager(),
+                                                             environment: .development)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -97,7 +99,8 @@ final class ScheduleViewController: BaseViewController {
         getMySchedules(date: "2022-06-04")
         getMyPillLists(date: "2022-06-22")
 //        getMemberSchedules(memberId: 187, date: "2022-06-22")
-        getMemberPillLists(memberId: 187, date: "2022-06-22")
+//        getMemberPillLists(memberId: 187, date: "2022-06-22")
+        getStickers(for: 13161)
     }
     
     override func style() {

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
@@ -100,7 +100,8 @@ final class ScheduleViewController: BaseViewController {
         getMyPillLists(date: "2022-06-22")
 //        getMemberSchedules(memberId: 187, date: "2022-06-22")
 //        getMemberPillLists(memberId: 187, date: "2022-06-22")
-        getStickers(for: 13161)
+//        getStickers(for: 13161)
+        postSticker(for: 13530, withSticker: 3)
     }
     
     override func style() {

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
@@ -101,7 +101,8 @@ final class ScheduleViewController: BaseViewController {
 //        getMemberSchedules(memberId: 187, date: "2022-06-22")
 //        getMemberPillLists(memberId: 187, date: "2022-06-22")
 //        getStickers(for: 13161)
-        postSticker(for: 13530, withSticker: 3)
+//        postSticker(for: 13530, withSticker: 3)
+        changeSticker(for: 151, withSticker: 1)
     }
     
     override func style() {


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->
스티커 관련 API를 연결했습니다. 프로젝트 내에 데이터 넘어오는 거 전부 확인했고, 데이터 연결은 merge 이후에 일괄적으로 처리하겠습니다.
(시간이 촉박해서 일단 붙이는 작업 먼저 빠르게 진행했어요...😂)

🌱 작업한 브랜치

- feature/#240

🌱 작업한 내용

`11/13`
- [x] GET_받은 스티커 모두 확인
- [x] GET_전송할 스티커 전체보기 : 해당 API는 보내야 하는 스티커가 결국 1~6사이라서 직접적인 통신은 안하고자 합니다.
- [x] POST_스티커 전송
- [x] PUT_보낸 스티커 수정 : Response 수정 요청해야 하는 부분이 보입니다.

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | - |

## 📮 관련 이슈

- Resolved: #240
