### PR TITLE
[#273] 홈, 공유 디자인 QA 1차 반영

### DIFF
--- a/SobokSobok/SobokSobok/Presentation/Common/TabBarController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Common/TabBarController.swift
@@ -43,7 +43,7 @@ extension TabBarController {
     private func setTabBarAppearance() {
         UITabBar.clearShadow()
         UITabBar.appearance().tintColor = Color.black
-        UITabBar.appearance().unselectedItemTintColor = Color.gray500
+        UITabBar.appearance().unselectedItemTintColor = Color.gray800
 
         let fontAttributes = [NSAttributedString.Key.font: UIFont(name: "Pretendard-Bold", size: 11.0)!]
         UITabBarItem.appearance().setTitleTextAttributes(fontAttributes, for: .normal)

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+FSCalendar.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+FSCalendar.swift
@@ -16,6 +16,7 @@ extension ScheduleViewController {
         calendarView.headerHeight = 0
         calendarView.firstWeekday = 2
         calendarView.setScope(.week, animated: false)
+        calendarView.select(Date())
     }
     
     func setCalendarStyle() {

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
@@ -166,7 +166,7 @@ final class ScheduleViewController: BaseViewController {
         
         calendarView.snp.makeConstraints {
             // calendar left, right padding 10씩 조정하기
-            $0.leading.trailing.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(8)
             $0.height.equalTo(calendarHeight)
         }
 

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
@@ -278,7 +278,7 @@ extension ScheduleViewController {
     private func updateUI() {
         friendNameView.isHidden = friendName == nil ? true : false
         friendNameView.friendNameLabel.text = friendName
-        calendarTopView.dateLabel.text = currentDate.toString(of: .day)
+        calendarTopView.dateLabel.text = calendarTopView.scopeState == .week ? currentDate.toString(of: .day) : currentDate.toString(of: .month)
     }
     
     private func setDelegation() {
@@ -372,6 +372,7 @@ extension ScheduleViewController: CalendarTopViewDelegate {
         calendarView.setScope(scope == .week ? .week : .month, animated: true)
         calendarTopView.scopeButton.setTitle(scope == .week ? "주" : "월", for: .normal)
         calendarTopView.scopeButton.setImage(scope == .week ? Image.icArrowDropDown16 : Image.icArrowUp16, for: .normal)
+        calendarTopView.dateLabel.text = scope == .week ? currentDate.toString(of: .day) : currentDate.toString(of: .month)
     }
 }
 

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Views/ScheduleHeaderView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Views/ScheduleHeaderView.swift
@@ -55,7 +55,9 @@ extension ScheduleHeaderView {
             $0.top.equalToSuperview().offset(36)
             $0.leading.equalToSuperview()
             $0.bottom.equalToSuperview().inset(6)
+            $0.height.equalTo(35.adjustedHeight)
         }
+        
         editButton.snp.makeConstraints {
             $0.top.equalToSuperview().offset(19)
             $0.trailing.equalToSuperview()


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->

🌱 작업한 브랜치

- feature/#273

🌱 작업한 내용

- 탭바 아이템 색상
- 처음 실행 시 오늘 날짜 선택모드
- 월로 바꿨을 때 텍스트 변경
- 시간과 약 사이 간격 조정
- 캘린더 좌우 여백 조정 (로그에 레이아웃 경고 문구 이후 수정 필요)

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | - |

## 📮 관련 이슈

- Resolved: #273
