### PR TITLE
[#283] 약 추가 캘린더 UI 및 기능 수정 

### DIFF
--- a/SobokSobok/SobokSobok/Presentation/Common/Sample/SampleViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Common/Sample/SampleViewController.swift
@@ -28,5 +28,18 @@ final class SampleViewController: BaseViewController {
             $0.width.height.equalTo(350)
             $0.center.equalToSuperview()
         }
+        
+        calendar.delegate = self
+        print("시작일로부터 3개월 선택 상황", calendar.firstDate, calendar.lastDate)
+    }
+}
+
+extension SampleViewController: CalendarViewDelegate {
+    func didSelectFirstDate(_ calendar: CalendarView) {
+        print("처음 날짜", calendar.firstDate)
+    }
+    
+    func didSelectLastDate(_ calendar: CalendarView) {
+        print("마지막 날짜", calendar.lastDate)
     }
 }

--- a/SobokSobok/SobokSobok/Presentation/Common/TabBarController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Common/TabBarController.swift
@@ -54,7 +54,7 @@ extension TabBarController {
 
     private func setTabBarItems() {
         tabs = [
-            UINavigationController(rootViewController: SampleViewController()),
+            UINavigationController(rootViewController: MainViewController()),
             UINavigationController(rootViewController: ShareViewController()),
             UINavigationController(rootViewController: NoticeViewController()),
             UINavigationController(rootViewController: UIViewController())

--- a/SobokSobok/SobokSobok/Presentation/Common/TabBarController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Common/TabBarController.swift
@@ -54,7 +54,7 @@ extension TabBarController {
 
     private func setTabBarItems() {
         tabs = [
-            UINavigationController(rootViewController: MainViewController()),
+            UINavigationController(rootViewController: SampleViewController()),
             UINavigationController(rootViewController: ShareViewController()),
             UINavigationController(rootViewController: NoticeViewController()),
             UINavigationController(rootViewController: UIViewController())

--- a/SobokSobok/SobokSobok/Presentation/Common/Views/CalendarView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Common/Views/CalendarView.swift
@@ -9,6 +9,11 @@ import UIKit
 
 import FSCalendar
 
+protocol CalendarViewDelegate: AnyObject {
+    func didSelectFirstDate(_ calendar: CalendarView)
+    func didSelectLastDate(_ calendar: CalendarView)
+}
+
 final class CalendarView: BaseView, FSCalendarDataSource, FSCalendarDelegate, FSCalendarDelegateAppearance {
     
     // MARK: - UIComponents
@@ -27,6 +32,8 @@ final class CalendarView: BaseView, FSCalendarDataSource, FSCalendarDelegate, FS
         $0.setImage(Image.icNextSmall48, for: .normal)
         $0.addTarget(self, action: #selector(moveToNext), for: .touchUpInside)
     }
+    
+    weak var delegate: CalendarViewDelegate?
 
     // MARK: - Date Properties
     
@@ -41,8 +48,16 @@ final class CalendarView: BaseView, FSCalendarDataSource, FSCalendarDelegate, FS
     private var components = DateComponents()
     private var currentPage: Date?
     private var currentDate = Date()
-    private var firstDate: Date?
-    private var lastDate: Date?
+    var firstDate: Date? {
+        didSet {
+            delegate?.didSelectFirstDate(self)
+        }
+    }
+    var lastDate: Date? {
+        didSet {
+            delegate?.didSelectLastDate(self)
+        }
+    }
     private var datesRange: [Date]?
 
     override func setupView() {

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Cells/CalendarDayCell.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Cells/CalendarDayCell.swift
@@ -163,11 +163,13 @@ class DIYCalendarCell: FSCalendarCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        self.selectionLayer?.frame = self.contentView.bounds//.insetBy(dx: 0, dy: 3)
-        self.connectionLayer?.frame = self.contentView.bounds//.insetBy(dx: 0, dy: 3)
+        
+        self.selectionLayer?.frame = self.contentView.bounds.insetBy(dx: 0, dy: -3)
+        self.connectionLayer?.frame = self.contentView.bounds.insetBy(dx: 0, dy: -3)
         guard var connectionRect = connectionLayer?.bounds else {
             return
         }
+        
         connectionRect.size.height = connectionRect.height * 5 / 6
         if selectionType == .middle {
             self.connectionLayer?.isHidden = false


### PR DESCRIPTION
## 🌴 PR 요약

 약 추가 캘린더 UI 및 기능 수정 

🌱 작업한 브랜치

- feature/#283

🌱 작업한 내용

- 3개월 체크 버튼 삭제
- 시작 날짜, 마지막 날짜 가져올 수 있도록 Delegate 메서드 구현
- UI 디테일 수정 (날짜 길게 선택했을 때 셀 간의 간격이 좁은 부분이 있는데 지금 당장 수치 계산이 어려워 이 부분은 아직 구현안했습니다.)

@seungchan2 
- 약 추가 뷰에서 시작 날짜와 마지막 날짜가 변할 때 마다 값을 받아올 수 있도록 Delegate 메서드를 구현했습니다.
- 시작 날짜는 firstDate, 마지막 날짜는 lastDate로 접근가능합니다. 각각 Date? (옵셔널 타입입니다.)
- 처음 시작 시 기본 값이 선택되어 있습니다.

1. 인스턴스 생성
```swift
let calendarView = CalendarView()
```

2. 대리자 위임, 프로토콜 연결
```swift
calendarView.delegate = self
```

3. 처음 로드 시 시작 날짜, 마지막 날짜 접근 (기본적으로 3개월이 체크된 채로 시작되어 프로퍼티에 값이 담겨 있어요.
```swift
print("시작일로부터 3개월 선택 상황", calendarView.firstDate, calendarView.lastDate)
```

4. 프로토콜 필수 메서드를 구현하면 변하는 값을 캐치할 수 있습니다.
> CalendarViewDelegate 프로토콜을 채택하면 필수 메서드가 나옵니다.
> 각각 시작 날짜, 마지막 날짜를 선택할 때마다 실행되며, 값이 선택되지 않았거나 모두 해제되면 nil 값을 반환합니다.
```swift
extension SampleViewController: CalendarViewDelegate {
    func didSelectFirstDate(_ calendar: CalendarView) {
        print("처음 날짜", calendarView.firstDate)
    }
    
    func didSelectLastDate(_ calendar: CalendarView) {
        print("마지막 날짜", calendarView.lastDate)
    }
}
```

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  |<img src = "https://user-images.githubusercontent.com/61109660/184664791-45e0b77a-a474-42d8-ba91-8deb13aa0c00.png" width = "300" />|

## 📮 관련 이슈

- Resolved: #283
