### PR TITLE
[#286] 소셜 로그인(애플) 및 회원가입 구현

### DIFF
--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -62,6 +62,10 @@
 		BD382F75286DEE83002E91F0 /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD382F74286DEE83002E91F0 /* EndPoint.swift */; };
 		BD38CB4028AB2546006CB0FB /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38CB3F28AB2546006CB0FB /* UserDefaultsManager.swift */; };
 		BD38CB6C28AB9082006CB0FB /* AppleLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38CB6B28AB9082006CB0FB /* AppleLoginManager.swift */; };
+		BD38CB6E28AB94BF006CB0FB /* AuthEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38CB6D28AB94BF006CB0FB /* AuthEndPoint.swift */; };
+		BD38CB7028AB94C9006CB0FB /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38CB6F28AB94C9006CB0FB /* AuthManager.swift */; };
+		BD38CB7228AB9764006CB0FB /* SocialUserRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38CB7128AB9764006CB0FB /* SocialUserRequest.swift */; };
+		BD38CB7428AB976C006CB0FB /* SocialUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38CB7328AB976C006CB0FB /* SocialUserResponse.swift */; };
 		BD4611C128608260007BEE87 /* FriendNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4611C028608260007BEE87 /* FriendNameView.swift */; };
 		BD4611C328608389007BEE87 /* CalendarTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4611C228608389007BEE87 /* CalendarTopView.swift */; };
 		BD4611C52860868C007BEE87 /* HomeTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4611C42860868C007BEE87 /* HomeTopView.swift */; };
@@ -313,6 +317,10 @@
 		BD382F74286DEE83002E91F0 /* EndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPoint.swift; sourceTree = "<group>"; };
 		BD38CB3F28AB2546006CB0FB /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		BD38CB6B28AB9082006CB0FB /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
+		BD38CB6D28AB94BF006CB0FB /* AuthEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthEndPoint.swift; sourceTree = "<group>"; };
+		BD38CB6F28AB94C9006CB0FB /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
+		BD38CB7128AB9764006CB0FB /* SocialUserRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialUserRequest.swift; sourceTree = "<group>"; };
+		BD38CB7328AB976C006CB0FB /* SocialUserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialUserResponse.swift; sourceTree = "<group>"; };
 		BD4611C028608260007BEE87 /* FriendNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendNameView.swift; sourceTree = "<group>"; };
 		BD4611C228608389007BEE87 /* CalendarTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTopView.swift; sourceTree = "<group>"; };
 		BD4611C42860868C007BEE87 /* HomeTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTopView.swift; sourceTree = "<group>"; };
@@ -540,6 +548,8 @@
 			isa = PBXGroup;
 			children = (
 				9A3DF08B279660A400D07A8C /* Sign.swift */,
+				BD38CB7128AB9764006CB0FB /* SocialUserRequest.swift */,
+				BD38CB7328AB976C006CB0FB /* SocialUserResponse.swift */,
 			);
 			name = Sign;
 			sourceTree = "<group>";
@@ -641,6 +651,7 @@
 				EC4A3819289A68BF00974D7E /* PillCountlManager.swift */,
 				BDDF7722289A95340096196B /* StickerManager.swift */,
 				ECCF5E52289F8C0000BC6862 /* SendPillManager.swift */,
+				BD38CB6F28AB94C9006CB0FB /* AuthManager.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -653,6 +664,7 @@
 				EC9EDE41289A51FB00855ED7 /* PillCountEndPoint.swift */,
 				BDDF7720289A952B0096196B /* StickerEndPoint.swift */,
 				ECCF5E50289F8BF500BC6862 /* SendPillEndPoint.swift */,
+				BD38CB6D28AB94BF006CB0FB /* AuthEndPoint.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1951,6 +1963,7 @@
 				BD149DCD278B3369009AA416 /* TabBarController.swift in Sources */,
 				9A3DF0B427981C6A00D07A8C /* SearchNicknameModel.swift in Sources */,
 				9A3DF0C92799EFEC00D07A8C /* EditFriendUsername.swift in Sources */,
+				BD38CB7428AB976C006CB0FB /* SocialUserResponse.swift in Sources */,
 				BD7120EF2796B3850068B981 /* ScheduleAPI.swift in Sources */,
 				EC03760E278B2E4000CA4B54 /* AddPillSheet.swift in Sources */,
 				BD2C8B3C27953B8100B1F59D /* PagerTab.swift in Sources */,
@@ -2076,6 +2089,8 @@
 				EC02140427D0F85000CF3569 /* PillDayViewModel.swift in Sources */,
 				EC91946428224BBF0047893F /* AddPillInfoViewController.swift in Sources */,
 				EC02141627D27CD900CF3569 /* PillDayViewController.swift in Sources */,
+				BD38CB6E28AB94BF006CB0FB /* AuthEndPoint.swift in Sources */,
+				BD38CB7028AB94C9006CB0FB /* AuthManager.swift in Sources */,
 				BD149DCB278B31DC009AA416 /* TabBarItem.swift in Sources */,
 				F605028027BE6CAD0010DEC8 /* NoticeListView.swift in Sources */,
 				EC0213F227CF44D500CF3569 /* SpecificView.swift in Sources */,
@@ -2107,6 +2122,7 @@
 				ECFE3F80288FCC2200150699 /* SendFillFirstView.swift in Sources */,
 				EC4A381A289A68BF00974D7E /* PillCountlManager.swift in Sources */,
 				ECCF5E53289F8C0000BC6862 /* SendPillManager.swift in Sources */,
+				BD38CB7228AB9764006CB0FB /* SocialUserRequest.swift in Sources */,
 				BDDAA5A92789BCD3000C0AF8 /* UserDefaultKey.swift in Sources */,
 				9A3DF0B727981D8600D07A8C /* AddAccountService.swift in Sources */,
 				F695168C289D0915000F88D7 /* NoticeManager.swift in Sources */,

--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		BD382F71286DA350002E91F0 /* ScheduleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD382F70286DA350002E91F0 /* ScheduleManager.swift */; };
 		BD382F75286DEE83002E91F0 /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD382F74286DEE83002E91F0 /* EndPoint.swift */; };
 		BD38CB4028AB2546006CB0FB /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38CB3F28AB2546006CB0FB /* UserDefaultsManager.swift */; };
+		BD38CB6C28AB9082006CB0FB /* AppleLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38CB6B28AB9082006CB0FB /* AppleLoginManager.swift */; };
 		BD4611C128608260007BEE87 /* FriendNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4611C028608260007BEE87 /* FriendNameView.swift */; };
 		BD4611C328608389007BEE87 /* CalendarTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4611C228608389007BEE87 /* CalendarTopView.swift */; };
 		BD4611C52860868C007BEE87 /* HomeTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4611C42860868C007BEE87 /* HomeTopView.swift */; };
@@ -311,6 +312,7 @@
 		BD382F70286DA350002E91F0 /* ScheduleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleManager.swift; sourceTree = "<group>"; };
 		BD382F74286DEE83002E91F0 /* EndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPoint.swift; sourceTree = "<group>"; };
 		BD38CB3F28AB2546006CB0FB /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
+		BD38CB6B28AB9082006CB0FB /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
 		BD4611C028608260007BEE87 /* FriendNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendNameView.swift; sourceTree = "<group>"; };
 		BD4611C228608389007BEE87 /* CalendarTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTopView.swift; sourceTree = "<group>"; };
 		BD4611C42860868C007BEE87 /* HomeTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTopView.swift; sourceTree = "<group>"; };
@@ -1589,6 +1591,7 @@
 			children = (
 				ECAF4D26284F3B1C00B12DA7 /* Helper.swift */,
 				BD38CB3F28AB2546006CB0FB /* UserDefaultsManager.swift */,
+				BD38CB6B28AB9082006CB0FB /* AppleLoginManager.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -2087,6 +2090,7 @@
 				EC8596AA281C023800850E84 /* AddPillSecondView.swift in Sources */,
 				F605027E27BE3BC60010DEC8 /* NoticeViewController.swift in Sources */,
 				EC919468282252230047893F /* PillPeriodTimeView.swift in Sources */,
+				BD38CB6C28AB9082006CB0FB /* AppleLoginManager.swift in Sources */,
 				BD38CB4028AB2546006CB0FB /* UserDefaultsManager.swift in Sources */,
 				BDE2ADE42891266200A42559 /* ShareTopView.swift in Sources */,
 				EC8596AE281C05CF00850E84 /* AddPillSecondViewController.swift in Sources */,

--- a/SobokSobok/SobokSobok/Common/Helper/AppleLoginManager.swift
+++ b/SobokSobok/SobokSobok/Common/Helper/AppleLoginManager.swift
@@ -1,0 +1,46 @@
+//
+//  AppleLoginManager.swift
+//  SobokSobok
+//
+//  Created by taekki on 2022/08/16.
+//
+
+import UIKit
+import AuthenticationServices
+
+protocol AppleLoginManagerDelegate: AnyObject {
+    func appleLoginDidComplete(userID: String)
+    func appleLoginDidFail()
+}
+
+final class AppleLoginManager: NSObject {
+    weak var viewController: UIViewController?
+    weak var delegate: AppleLoginManagerDelegate?
+    
+    func configureAppleLoginPresentationAnchorView(_ view: UIViewController) {
+        self.viewController = view
+    }
+}
+
+extension AppleLoginManager: ASAuthorizationControllerPresentationContextProviding {
+    
+    // 인증창을 띄워야 하는 뷰 반환
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return viewController!.view.window!
+    }
+}
+
+extension AppleLoginManager: ASAuthorizationControllerDelegate {
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
+
+            let userID = credential.user
+            delegate?.appleLoginDidComplete(userID: userID)
+        }
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        delegate?.appleLoginDidFail()
+    }
+}

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/SocialUserRequest.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/SocialUserRequest.swift
@@ -9,7 +9,6 @@ import Foundation
 
 struct SocialUserRequest: Codable {
     let socialId: String
-    let email: String?
-    let username: String?
+    let username: String
     let deviceToken: String
 }

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/SocialUserRequest.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/SocialUserRequest.swift
@@ -1,0 +1,15 @@
+//
+//  SocialUserRequest.swift
+//  SobokSobok
+//
+//  Created by taekki on 2022/08/16.
+//
+
+import Foundation
+
+struct SocialUserRequest: Codable {
+    let socialId: String
+    let email: String?
+    let username: String?
+    let deviceToken: String
+}

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/SocialUserResponse.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/SocialUserResponse.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 struct SignUpResponse: Codable {
-    let id: Int
-    let username: String
-    let email: String
-    let socialId: String
-    let accesstoken: String
-    let isNew: Bool
+    let id: Int?
+    let username: String?
+    let socialId: String?
+    let deviceToken: String?
+    let accesstoken: String?
+    let isNew: Bool?
 }
 
 struct SignInResponse: Codable {

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/SocialUserResponse.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/SocialUserResponse.swift
@@ -1,0 +1,22 @@
+//
+//  SocialUserResponse.swift
+//  SobokSobok
+//
+//  Created by taekki on 2022/08/16.
+//
+
+import Foundation
+
+struct SignUpResponse: Codable {
+    let id: Int
+    let username: String
+    let email: String
+    let socialId: String
+    let accesstoken: String
+    let isNew: Bool
+}
+
+struct SignInResponse: Codable {
+    let accesstoken: String
+    let isNew: Bool
+}

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/SocialUserResponse.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/SocialUserResponse.swift
@@ -17,6 +17,6 @@ struct SignUpResponse: Codable {
 }
 
 struct SignInResponse: Codable {
-    let accesstoken: String
+    let accesstoken: String?
     let isNew: Bool
 }

--- a/SobokSobok/SobokSobok/Network/API/AuthEndPoint.swift
+++ b/SobokSobok/SobokSobok/Network/API/AuthEndPoint.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum AuthEndPoint {
-    case signUp(body: SocialUserRequest)
+    case signUp(socialId: String, username: String, deviceToken: String)
     case signIn(socialId: String, deviceToken: String)
 }
 
@@ -24,8 +24,13 @@ extension AuthEndPoint: EndPoint {
     
     var body: Data? {
         switch self {
-        case .signUp(let body):
-            return body.encode()
+        case .signUp(let socialId, let username, let deviceToken):
+            let parameter = [
+                "socialId": socialId,
+                "username": username,
+                "deviceToken": deviceToken
+            ]
+            return parameter.encode()
         case .signIn:
             return nil
         }
@@ -42,9 +47,27 @@ extension AuthEndPoint: EndPoint {
     }
     
     func createRequest(environment: APIEnvironment) -> NetworkRequest {
-        return NetworkRequest(url: getURL(from: environment),
-                              httpMethod: method,
-                              requestBody: body,
-                              headers: nil)
+        
+        switch self {
+        case .signUp:
+            var headers: [String: String] = [:]
+            headers["Content-Type"] = "application/json"
+            return NetworkRequest(url: getURL(from: environment),
+                                  httpMethod: method,
+                                  requestBody: body,
+                                  headers: headers)
+            
+        case .signIn(let socialId, let deviceToken):
+            var headers: [String: String] = [:]
+            headers["Content-Type"] = "application/json"
+            headers["socialId"] = socialId
+            headers["deviceToken"] = deviceToken
+            return NetworkRequest(url: getURL(from: environment),
+                                  httpMethod: method,
+                                  requestBody: body,
+                                  headers: headers)
+        }
+        
+
     }
 }

--- a/SobokSobok/SobokSobok/Network/API/AuthEndPoint.swift
+++ b/SobokSobok/SobokSobok/Network/API/AuthEndPoint.swift
@@ -1,0 +1,43 @@
+//
+//  AuthEndPoint.swift
+//  SobokSobok
+//
+//  Created by taekki on 2022/08/16.
+//
+
+import Foundation
+
+enum AuthEndPoint {
+    case signUp(body: SocialUserRequest)
+    case signIn(socialId: String, deviceToken: String)
+}
+
+extension AuthEndPoint: EndPoint {
+    var method: HttpMethod {
+        switch self {
+        case .signUp:
+            return .POST
+        case .signIn:
+            return .GET
+        }
+    }
+    
+    var body: Data? {
+        switch self {
+        case .signUp(let body):
+            return body.encode()
+        case .signIn:
+            return nil
+        }
+    }
+    
+    func getURL(from environment: APIEnvironment) -> String {
+        let baseURL = environment.baseURL
+        switch self {
+        case .signUp:
+            return "\(baseURL)/auth/signup"
+        case .signIn(let socialId, let deviceToken):
+            return "\(baseURL)/auth/signin?socialId=\(socialId)&deviceToken=\(deviceToken)"
+        }
+    }
+}

--- a/SobokSobok/SobokSobok/Network/API/AuthEndPoint.swift
+++ b/SobokSobok/SobokSobok/Network/API/AuthEndPoint.swift
@@ -40,4 +40,11 @@ extension AuthEndPoint: EndPoint {
             return "\(baseURL)/auth/signin?socialId=\(socialId)&deviceToken=\(deviceToken)"
         }
     }
+    
+    func createRequest(environment: APIEnvironment) -> NetworkRequest {
+        return NetworkRequest(url: getURL(from: environment),
+                              httpMethod: method,
+                              requestBody: body,
+                              headers: nil)
+    }
 }

--- a/SobokSobok/SobokSobok/Network/Foundation/APIManager.swift
+++ b/SobokSobok/SobokSobok/Network/Foundation/APIManager.swift
@@ -18,6 +18,8 @@ final class APIManager: Requestable {
             throw APIError.urlEncodingError
         }
         
+        print(11111, encodedURL)
+        
         let (data, response) = try await URLSession.shared.data(for: request.createURLRequest(with: url))
         guard let httpResponse = response as? HTTPURLResponse,
               (200..<500) ~= httpResponse.statusCode else {
@@ -25,6 +27,8 @@ final class APIManager: Requestable {
         }
         
         let decodedData = try JSONDecoder().decode(BaseModel<T>.self, from: data)
+        dump(decodedData)
+        
         if decodedData.success {
             return decodedData.data
         } else {

--- a/SobokSobok/SobokSobok/Network/Service/AuthManager.swift
+++ b/SobokSobok/SobokSobok/Network/Service/AuthManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol AuthServiceable {
-    func signUp(body: SocialUserRequest) async throws -> SignUpResponse?
+    func signUp(socialId: String, username: String, deviceToken: String) async throws -> SignUpResponse?
     func signIn(socialId: String, deviceToken: String) async throws -> SignInResponse?
 }
 
@@ -21,9 +21,9 @@ struct AuthManager: AuthServiceable {
         self.environment = environment
     }
     
-    func signUp(body: SocialUserRequest) async throws -> SignUpResponse? {
+    func signUp(socialId: String, username: String, deviceToken: String) async throws -> SignUpResponse? {
         let request = AuthEndPoint
-            .signUp(body: body)
+            .signUp(socialId: socialId, username: username, deviceToken: deviceToken)
             .createRequest(environment: environment)
         return try await self.apiService.request(request)
     }

--- a/SobokSobok/SobokSobok/Network/Service/AuthManager.swift
+++ b/SobokSobok/SobokSobok/Network/Service/AuthManager.swift
@@ -1,0 +1,37 @@
+//
+//  AuthManager.swift
+//  SobokSobok
+//
+//  Created by taekki on 2022/08/16.
+//
+
+import Foundation
+
+protocol AuthServiceable {
+    func signUp(body: SocialUserRequest) async throws -> SignUpResponse?
+    func signIn(socialId: String, deviceToken: String) async throws -> SignInResponse?
+}
+
+struct AuthManager: AuthServiceable {
+    private let apiService: Requestable
+    private let environment: APIEnvironment
+    
+    init(apiService: Requestable, environment: APIEnvironment) {
+        self.apiService = apiService
+        self.environment = environment
+    }
+    
+    func signUp(body: SocialUserRequest) async throws -> SignUpResponse? {
+        let request = AuthEndPoint
+            .signUp(body: body)
+            .createRequest(environment: environment)
+        return try await self.apiService.request(request)
+    }
+    
+    func signIn(socialId: String, deviceToken: String) async throws -> SignInResponse? {
+        let request = AuthEndPoint
+            .signIn(socialId: socialId, deviceToken: deviceToken)
+            .createRequest(environment: environment)
+        return try await self.apiService.request(request)
+    }
+}

--- a/SobokSobok/SobokSobok/Presentation/SignIn/SocialSignInViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignIn/SocialSignInViewController.swift
@@ -59,7 +59,8 @@ extension SocialSignInViewController {
 
 extension SocialSignInViewController: AppleLoginManagerDelegate {
     func appleLoginDidComplete(userID: String) {
-        signIn(socialID: userID)
+        let appleSocialId = "Apple@" + userID
+        signIn(socialID: appleSocialId)
     }
     
     func appleLoginDidFail() {
@@ -76,20 +77,22 @@ extension SocialSignInViewController {
             guard let isNewUser = result?.isNew else { return }
             
             if isNewUser {
-                transitionToSetNickNameViewController()
+                transitionToSetNickNameViewController(socialId: socialID)
+                
             } else {
                 transitionToMainViewController()
             }
         }
     }
     
-    func transitionToSetNickNameViewController() {
+    func transitionToSetNickNameViewController(socialId: String) {
         let setNickNameViewController = SetNickNameVIewController()
+        setNickNameViewController.socialId = socialId
         navigationController?.pushViewController(setNickNameViewController, animated: true)
     }
     
     func transitionToMainViewController() {
-        let mainViewController = MainViewController()
+        let mainViewController = TabBarController()
         navigationController?.pushViewController(mainViewController, animated: true)
     }
 }

--- a/SobokSobok/SobokSobok/Presentation/SignIn/SocialSignInViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignIn/SocialSignInViewController.swift
@@ -16,6 +16,7 @@ final class SocialSignInViewController: UIViewController, SocialSignInProtocol {
     @IBOutlet weak var appleLoginButton: UIView!
     
     lazy var appleLoginManager = AppleLoginManager()
+    lazy var authManager = AuthManager(apiService: APIManager(), environment: .development)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -58,10 +59,37 @@ extension SocialSignInViewController {
 
 extension SocialSignInViewController: AppleLoginManagerDelegate {
     func appleLoginDidComplete(userID: String) {
-
+        signIn(socialID: userID)
     }
     
     func appleLoginDidFail() {
         
+    }
+}
+
+extension SocialSignInViewController {
+    
+    func signIn(socialID: String) {
+        Task {
+            let result = try await authManager.signIn(socialId: socialID, deviceToken: UserDefaultsManager.fcmToken)
+            
+            guard let isNewUser = result?.isNew else { return }
+            
+            if isNewUser {
+                transitionToSetNickNameViewController()
+            } else {
+                transitionToMainViewController()
+            }
+        }
+    }
+    
+    func transitionToSetNickNameViewController() {
+        let setNickNameViewController = SetNickNameVIewController()
+        navigationController?.pushViewController(setNickNameViewController, animated: true)
+    }
+    
+    func transitionToMainViewController() {
+        let mainViewController = MainViewController()
+        navigationController?.pushViewController(mainViewController, animated: true)
     }
 }

--- a/SobokSobok/SobokSobok/Presentation/SignIn/SocialSignInViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignIn/SocialSignInViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import AuthenticationServices
 
 protocol SocialSignInProtocol: StyleProtocol {}
 
@@ -14,9 +15,13 @@ final class SocialSignInViewController: UIViewController, SocialSignInProtocol {
     @IBOutlet weak var kakaoLoginButton: UIView!
     @IBOutlet weak var appleLoginButton: UIView!
     
+    lazy var appleLoginManager = AppleLoginManager()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+     
         style()
+        configureAppleLoginManager()
     }
     
     func style() {
@@ -27,8 +32,36 @@ final class SocialSignInViewController: UIViewController, SocialSignInProtocol {
     @IBAction func signInWithKakao(_ sender: UIView) {
         print("kakao")
     }
+    
     @IBAction func signInWIthApple(_ sender: UIView) {
-        print("apple")
+        handleAppleAuthentication()
+    }
+}
+
+extension SocialSignInViewController {
+    
+    private func configureAppleLoginManager() {
+        appleLoginManager.delegate = self
     }
     
+    private func handleAppleAuthentication() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.presentationContextProvider = appleLoginManager
+        controller.delegate = appleLoginManager
+        controller.performRequests()
+    }
+}
+
+extension SocialSignInViewController: AppleLoginManagerDelegate {
+    func appleLoginDidComplete(userID: String) {
+
+    }
+    
+    func appleLoginDidFail() {
+        
+    }
 }

--- a/SobokSobok/SobokSobok/Presentation/SignUp/CompleteSignUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignUp/CompleteSignUpViewController.swift
@@ -23,7 +23,16 @@ final class CompleteSignUpViewController: UIViewController, CompleteSingUpProtoc
     
     // MARK: - @IBAction Properties
     @IBAction func touchUpToStart(_ sender: UIButton) {
-        // 메인뷰로 화면 이동
-        navigationController?.pushViewController(TabBarController.instanceFromNib(), animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.transitionToMainViewController()
+        }
+    }
+    
+    func transitionToMainViewController() {
+        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+        let sceneDelegate = windowScene?.delegate as? SceneDelegate
+        let completeSignUpViewController = TabBarController.instanceFromNib()
+        sceneDelegate?.window?.rootViewController = UINavigationController(rootViewController: completeSignUpViewController)
+        sceneDelegate?.window?.makeKeyAndVisible()
     }
 }

--- a/SobokSobok/SobokSobok/Presentation/Splash/SplashView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Splash/SplashView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import Lottie
 
-final class SplashView: BaseViewController {
+final class SplashView: UIViewController {
     
     // MARK: - Properties
     lazy var lottiView: AnimationView = {
@@ -34,7 +34,7 @@ final class SplashView: BaseViewController {
         view.addSubview(lottiView)
         lottiView.isHidden = false
         lottiView.play { _ in
-            let nextVC = SignInViewController.instanceFromNib()
+            let nextVC = SocialSignInViewController.instanceFromNib()
             nextVC.modalTransitionStyle = .crossDissolve
             self.navigationController?.pushViewController(nextVC, animated: true)
         }

--- a/SobokSobok/SobokSobok/Service/Network/APIServices/Sign/SignService.swift
+++ b/SobokSobok/SobokSobok/Service/Network/APIServices/Sign/SignService.swift
@@ -50,7 +50,7 @@ extension SignService: TargetType {
                 "name": name
             ], encoding: JSONEncoding.default)
         case .checkUsername(let nickname):
-            return .requestParameters(parameters: ["nickname": nickname], encoding: JSONEncoding.default)
+            return .requestParameters(parameters: ["username": nickname], encoding: JSONEncoding.default)
         }
     }
     

--- a/SobokSobok/SobokSobok/SobokSobok.entitlements
+++ b/SobokSobok/SobokSobok/SobokSobok.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->
애플 로그인 및 회원가입을 구현했습니다.

🌱 작업한 브랜치

- feature/#298

🌱 작업한 내용

- 소셜 로그인, 회원가입 API 연결
- 애플 로그인
- 이미 있는 계정인 경우 메인 화면으로 넘어가는 것 확인
- 회원가입 성공 시 가입 완료 화면 확인

- 토큰은 가입된 계정으로 저장할 필요가 있고, 지금 현재는 더미 계정의 토큰 이용중입니다. (착오 없으시길 바랍니다.)
- 중간중간 인디케이터 필요해보입니다.
- 가입 후 메인으로 넘어갔을 때 푸시 알림 팝업 필요합니다.
- 소셜 로그인 화면에서 이미지 넣어야 합니다.
- 카카오 로그인 연결 필요합니다.

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | - |

## 📮 관련 이슈

- Resolved: #298
