### PR TITLE
[#297] 약 정보 상세보기 뷰 연결과 상세보기 데이터 전달

### DIFF
--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/NoticeViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/NoticeViewController.swift
@@ -75,7 +75,6 @@ extension NoticeViewController: NoticeFistControl {
         let cell = noticeListView.noticeListCollectionView.dequeueReusableCell(
             for: indexPath, cellType: NoticeListCollectionViewCell.self
         )
-        cell.setupView(section: .pill, status: .waite)
         
         if noticeList?.infoList[indexPath.row].section == "calendar" {
             if noticeList?.infoList[indexPath.row].isOkay == "waiting" {
@@ -224,14 +223,14 @@ extension NoticeViewController: NoticeFistControl {
                 cell.setupView(section: .pill, status: .done)
                 
                 createdAt = dateFormatter.date(from: createdAt)?.toString(of: .noticeDay) ?? ""
-                cell.descriptionLabel.text = groupName + "이 보낸 약 알림 일정을 수락했어요"
+                cell.descriptionLabel.text = groupName + "님이 보낸 약 알림 일정을 수락했어요"
                 cell.timeLabel.text = createdAt
             }
             else if noticeList?.infoList[indexPath.row].isOkay == "refuse" {
                 cell.setupView(section: .pill, status: .done)
                 
                 createdAt = dateFormatter.date(from: createdAt)?.toString(of: .noticeDay) ?? ""
-                cell.descriptionLabel.text = groupName + "이 보낸 약 알림 일정을 거절했어요"
+                cell.descriptionLabel.text = groupName + "님이 보낸 약 알림 일정을 거절했어요"
                 cell.timeLabel.text = createdAt
             }
             else { fatalError("존재하지 않는 case") }

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/NoticeViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/NoticeViewController.swift
@@ -11,12 +11,12 @@ final class NoticeViewController: UIViewController {
     // MARK: - Properties
     var noticeList: NoticeList? {
         didSet {
-            noticeListView.noticeListCollectionView.reloadData()
+            self.noticeListView.noticeListCollectionView.reloadData()
         }
     }
     var friendInfo: AcceptFriend? {
         didSet {
-            noticeListView.noticeListCollectionView.reloadData()
+            self.noticeListView.noticeListCollectionView.reloadData()
         }
     }
     let noticeListManager: NoticeServiceable = NoticeManager(apiService: APIManager(), environment: .development)
@@ -49,13 +49,9 @@ final class NoticeViewController: UIViewController {
 extension NoticeViewController: NoticeFistControl {
     func assignDelegation() {
         noticeListView.noticeListCollectionView.collectionViewLayout = createSection()
-        noticeListView.noticeListCollectionView.delegate = self
         noticeListView.noticeListCollectionView.dataSource = self
     }
  }
-
- extension NoticeViewController: UICollectionViewDelegate { }
-
  extension NoticeViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if noticeList?.infoList.isEmpty == true {
@@ -81,8 +77,8 @@ extension NoticeViewController: NoticeFistControl {
         )
         cell.setupView(section: .pill, status: .waite)
         
-        if noticeList?.infoList[indexPath.row].section == "calender" {
-            if noticeList?.infoList[indexPath.row].isOkay == "wait" {
+        if noticeList?.infoList[indexPath.row].section == "calendar" {
+            if noticeList?.infoList[indexPath.row].isOkay == "waiting" {
                 cell.setupView(section: .calender, status: .waite)
                 
                 createdAt = dateFormatter.date(from: createdAt)?.toString(of: .calendarTime) ?? ""
@@ -144,7 +140,7 @@ extension NoticeViewController: NoticeFistControl {
             else { fatalError("존재하지 않는 case") }
         }
         else if noticeList?.infoList[indexPath.row].section == "pill" {
-            if noticeList?.infoList[indexPath.row].isOkay == "wait" {
+            if noticeList?.infoList[indexPath.row].isOkay == "waiting" {
                 cell.setupView(section: .pill, status: .waite)
                 
                 createdAt = dateFormatter.date(from: createdAt)?.toString(of: .calendarTime) ?? ""
@@ -168,7 +164,7 @@ extension NoticeViewController: NoticeFistControl {
                         message: "수락하면 홈 캘린더에 약이 추가되고,\n정해진 시간에 알림을 받을 수 있어요 ",
                         accept: "확인",
                         viewController: self) {
-                            if acceptedPillCount <= 5 {
+                            if acceptedPillCount < 5 {
                                 cell.setupView(section: .pill, status: .done)
                                 
                                 createdAt = dateFormatter.date(from: createdAt)?.toString(of: .noticeDay) ?? ""

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListCollectionViewCell.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListCollectionViewCell.swift
@@ -107,14 +107,14 @@ final class NoticeListCollectionViewCell: UICollectionViewCell, NoticeListPresen
         statusType = status
         divideSection()
         
-        topStackView.addArrangedSubviews(iconImageView, nameLabel, detailButton, detailLabel, detailImageView)
+        topStackView.addArrangedSubviews(iconImageView, nameLabel, detailLabel, detailImageView)
         [detailLabel, detailImageView].forEach { $0.bringSubviewToFront(detailButton) }
         topStackView.bringSubviewToFront(toolTipView)
         middleStackView.addArrangedSubviews(lineView, descriptionLabel, timeLabel)
         bottomStackView.addArrangedSubviews(refuseButton, acceptButton)
         containerStackView.addArrangedSubviews(topStackView, middleStackView, bottomStackView)
         
-        contentView.addSubview(containerStackView)
+        contentView.addSubviews(detailButton, containerStackView)
         contentView.backgroundColor = Color.white
         contentView.makeRounded(radius: 12)
 
@@ -135,8 +135,14 @@ final class NoticeListCollectionViewCell: UICollectionViewCell, NoticeListPresen
         detailLabel.snp.makeConstraints { make in
             make.height.equalTo(25.adjustedHeight)
         }
-        detailImageView.snp.makeConstraints {
-            $0.width.height.equalTo(32.adjustedWidth)
+        detailImageView.snp.makeConstraints { make in
+            make.width.height.equalTo(48.adjustedWidth)
+        }
+        detailButton.snp.makeConstraints { make in
+            make.width.equalTo(72.adjustedWidth)
+            make.height.equalTo(21.adjustedHeight)
+            make.centerX.equalTo(topStackView.snp.trailing)
+            make.top.equalToSuperview().offset(18)
         }
 
         // MARK: - middle

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListCollectionViewCell.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListCollectionViewCell.swift
@@ -193,10 +193,17 @@ final class NoticeListCollectionViewCell: UICollectionViewCell, NoticeListPresen
         switch statusType {
         case .waite:
             descriptionLabel.textColor = Color.gray700
-            [topStackView, lineView, bottomStackView].forEach { $0.isHidden = false }
+            [topStackView, lineView, bottomStackView].forEach {
+                contentView.addSubview($0)
+                $0.isHidden = false
+                middleStackView.sendSubviewToBack($0)
+            }
         case .done:
             descriptionLabel.textColor = Color.gray600
-            [topStackView, lineView, bottomStackView].forEach { $0.isHidden = true }
+            [topStackView, lineView, bottomStackView].forEach {
+                $0.isHidden = true
+                $0.removeFromSuperview()
+            }
         }
     }
 }

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListCollectionViewCell.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListCollectionViewCell.swift
@@ -28,6 +28,10 @@ final class NoticeListCollectionViewCell: UICollectionViewCell, NoticeListPresen
     }
     
     // MARK: - UI Components
+    lazy var containerStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.distribution = .fill
+    }
     private lazy var topStackView =  UIStackView().then {
         $0.axis = .horizontal
         $0.distribution = .fill
@@ -108,72 +112,46 @@ final class NoticeListCollectionViewCell: UICollectionViewCell, NoticeListPresen
         topStackView.bringSubviewToFront(toolTipView)
         middleStackView.addArrangedSubviews(lineView, descriptionLabel, timeLabel)
         bottomStackView.addArrangedSubviews(refuseButton, acceptButton)
+        containerStackView.addArrangedSubviews(topStackView, middleStackView, bottomStackView)
         
-        contentView.addSubviews(topStackView, toolTipView, middleStackView, bottomStackView)
+        contentView.addSubview(containerStackView)
         contentView.backgroundColor = Color.white
         contentView.makeRounded(radius: 12)
+
     }
     
     func setupConstraint() {
-        topStackView.snp.makeConstraints { make in
-            make.width.equalTo(299.adjustedWidth)
-            make.height.equalTo(42.adjustedHeight)
-            make.top.equalToSuperview().offset(18)
-            make.centerX.equalToSuperview()
+        containerStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(18)
         }
+
+        // MARK: - top
         iconImageView.snp.makeConstraints { make in
             make.width.height.equalTo(22)
-            make.top.equalTo(topStackView.snp.bottom).offset(1.5)
-            make.leading.equalTo(topStackView.snp.leading)
         }
         nameLabel.snp.makeConstraints { make in
-            make.width.equalTo(156.adjustedWidth)
             make.height.equalTo(25.adjustedHeight)
-            make.top.equalTo(topStackView.snp.bottom)
-            make.leading.equalTo(iconImageView.snp.trailing)
         }
         detailLabel.snp.makeConstraints { make in
-            make.top.equalTo(topStackView.snp.bottom).offset(2)
-            make.centerX.equalTo(detailButton)
+            make.height.equalTo(25.adjustedHeight)
         }
-        detailImageView.snp.makeConstraints { make in
-            make.width.equalTo(48.adjustedWidth)
-            make.top.equalTo(topStackView.snp.bottom).offset(4.5)
-            make.leading.equalTo(detailLabel.snp.trailing).inset(1)
+        detailImageView.snp.makeConstraints {
+            $0.width.height.equalTo(32.adjustedWidth)
         }
-        detailButton.snp.makeConstraints { make in
-            make.width.equalTo(72.adjustedWidth)
-            make.height.equalTo(21.adjustedHeight)
-            make.leading.equalTo(nameLabel.snp.trailing).offset(39)
-        }
-        toolTipView.snp.makeConstraints { make in
-            make.width.equalTo(247.adjustedWidth)
-            make.height.equalTo(39.adjustedHeight)
-            make.top.equalToSuperview().offset(42)
-            make.trailing.equalToSuperview()
-        }
-        middleStackView.snp.makeConstraints { make in
-            make.width.equalTo(299.adjustedWidth)
-            make.height.equalTo(62.adjustedHeight)
-            make.top.equalTo(topStackView.snp.bottom)
-            make.leading.equalToSuperview().offset(18)
-        }
+
+        // MARK: - middle
         lineView.snp.makeConstraints { make in
             make.height.equalTo(2.adjustedHeight)
-            make.top.centerX.equalTo(middleStackView)
         }
         descriptionLabel.snp.makeConstraints { make in
-            make.top.equalTo(lineView.snp.bottom).offset(8)
+            make.height.equalTo(21)
         }
         timeLabel.snp.makeConstraints { make in
-            make.top.equalTo(descriptionLabel.snp.bottom)
+            make.height.equalTo(17)
         }
-        bottomStackView.snp.makeConstraints { make in
-            make.width.equalTo(299.adjustedWidth)
-            make.height.equalTo(40.adjustedHeight)
-            make.top.equalTo(middleStackView.snp.bottom).offset(8)
-            make.centerX.equalTo(middleStackView)
-            make.bottom.equalToSuperview().offset(18)
+        
+        bottomStackView.snp.makeConstraints {
+            $0.height.equalTo(40.adjustedHeight)
         }
         refuseButton.snp.makeConstraints { make in
             make.width.equalTo(146.adjustedWidth)

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListCollectionViewCell.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListCollectionViewCell.swift
@@ -31,27 +31,28 @@ final class NoticeListCollectionViewCell: UICollectionViewCell, NoticeListPresen
     private lazy var topStackView =  UIStackView().then {
         $0.axis = .horizontal
         $0.distribution = .fill
-        $0.spacing = 0
     }
     private lazy var iconImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFit
     }
     let nameLabel = UILabel().then {
-        $0.font = UIFont.font(FontType.pretendardSemibold, ofSize: 18)
+        $0.font = UIFont.font(.pretendardSemibold, ofSize: 18)
         $0.textAlignment = .left
         $0.textColor = Color.gray900
     }
-    let detailButton = UIButton()
-    let detailLabel = UILabel().then {
-        $0.font = UIFont.font(FontType.pretendardMedium, ofSize: 14)
+    private lazy var detailLabel = UILabel().then {
+        $0.font = UIFont.font(.pretendardMedium, ofSize: 14)
         $0.text = "상세보기"
         $0.textColor = Color.gray900
     }
     private lazy var detailImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFit
-        $0.image = Image.icMore16
+        $0.image = Image.icMoreBlack48
     }
-    let toolTipView = NoticeToolTipView(tipStartX: 184, tipWidth: 10, tipHeight: 6.2)
+    let detailButton = UIButton()
+    let toolTipView = NoticeToolTipView(tipStartX: 184, tipWidth: 10, tipHeight: 6.2).then {
+        $0.isHidden = true
+    }
     private lazy var middleStackView = UIStackView().then {
         $0.axis = .vertical
         $0.distribution = .fill
@@ -117,32 +118,33 @@ final class NoticeListCollectionViewCell: UICollectionViewCell, NoticeListPresen
         topStackView.snp.makeConstraints { make in
             make.width.equalTo(299.adjustedWidth)
             make.height.equalTo(42.adjustedHeight)
-            make.top.leading.equalToSuperview()
+            make.top.equalToSuperview().offset(18)
+            make.centerX.equalToSuperview()
         }
         iconImageView.snp.makeConstraints { make in
-            make.width.equalTo(22.adjustedWidth)
-            make.top.equalToSuperview().offset(1.5)
-            make.leading.equalToSuperview()
+            make.width.height.equalTo(22)
+            make.top.equalTo(topStackView.snp.bottom).offset(1.5)
+            make.leading.equalTo(topStackView.snp.leading)
         }
         nameLabel.snp.makeConstraints { make in
             make.width.equalTo(156.adjustedWidth)
             make.height.equalTo(25.adjustedHeight)
-            make.top.equalToSuperview()
-            make.leading.equalTo(iconImageView.snp.trailing).offset(10)
+            make.top.equalTo(topStackView.snp.bottom)
+            make.leading.equalTo(iconImageView.snp.trailing)
         }
         detailLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(2)
-            make.leading.equalTo(nameLabel.snp.trailing).offset(39)
+            make.top.equalTo(topStackView.snp.bottom).offset(2)
+            make.centerX.equalTo(detailButton)
         }
         detailImageView.snp.makeConstraints { make in
-            make.width.equalTo(16.adjustedWidth)
-            make.top.equalToSuperview().offset(4.5)
-            make.leading.equalTo(detailLabel.snp.trailing).offset(4)
+            make.width.equalTo(48.adjustedWidth)
+            make.top.equalTo(topStackView.snp.bottom).offset(4.5)
+            make.leading.equalTo(detailLabel.snp.trailing).inset(1)
         }
         detailButton.snp.makeConstraints { make in
             make.width.equalTo(72.adjustedWidth)
             make.height.equalTo(21.adjustedHeight)
-            make.centerX.equalTo(detailLabel)
+            make.leading.equalTo(nameLabel.snp.trailing).offset(39)
         }
         toolTipView.snp.makeConstraints { make in
             make.width.equalTo(247.adjustedWidth)
@@ -153,19 +155,25 @@ final class NoticeListCollectionViewCell: UICollectionViewCell, NoticeListPresen
         middleStackView.snp.makeConstraints { make in
             make.width.equalTo(299.adjustedWidth)
             make.height.equalTo(62.adjustedHeight)
-            make.top.leading.equalTo(topStackView)
+            make.top.equalTo(topStackView.snp.bottom)
+            make.leading.equalToSuperview().offset(18)
         }
         lineView.snp.makeConstraints { make in
             make.height.equalTo(2.adjustedHeight)
-            make.top.leading.trailing.equalToSuperview()
+            make.top.centerX.equalTo(middleStackView)
         }
         descriptionLabel.snp.makeConstraints { make in
             make.top.equalTo(lineView.snp.bottom).offset(8)
-            make.leading.trailing.equalToSuperview()
+        }
+        timeLabel.snp.makeConstraints { make in
+            make.top.equalTo(descriptionLabel.snp.bottom)
         }
         bottomStackView.snp.makeConstraints { make in
-            make.top.equalTo(middleStackView).offset(12)
-            make.leading.trailing.bottom.equalToSuperview()
+            make.width.equalTo(299.adjustedWidth)
+            make.height.equalTo(40.adjustedHeight)
+            make.top.equalTo(middleStackView.snp.bottom).offset(8)
+            make.centerX.equalTo(middleStackView)
+            make.bottom.equalToSuperview().offset(18)
         }
         refuseButton.snp.makeConstraints { make in
             make.width.equalTo(146.adjustedWidth)
@@ -177,17 +185,18 @@ final class NoticeListCollectionViewCell: UICollectionViewCell, NoticeListPresen
         switch sectionType {
         case .pill:
             iconImageView.image = Image.icPillAlarm
+            [detailLabel, detailImageView, detailButton].forEach { $0.isHidden = false }
         case .calender:
             iconImageView.image = Image.icShareAlarm
             [detailLabel, detailImageView, detailButton].forEach { $0.isHidden = true }
-            toolTipView.isHidden = true
         }
-        
         switch statusType {
         case .waite:
             descriptionLabel.textColor = Color.gray700
+            [topStackView, lineView, bottomStackView].forEach { $0.isHidden = false }
         case .done:
-            [topStackView, bottomStackView].forEach { $0.isHidden = true }
+            descriptionLabel.textColor = Color.gray600
+            [topStackView, lineView, bottomStackView].forEach { $0.isHidden = true }
         }
     }
 }

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListSection.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListSection.swift
@@ -12,7 +12,7 @@ extension NoticeViewController {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(180.adjustedHeight))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(180.adjustedHeight))
-        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitem: item, count: 1)
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 1)
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = .init(top: 18, leading: 0, bottom: 0, trailing: 0)
         section.interGroupSpacing = 8

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeSecond/PillInfoViewController+Network.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeSecond/PillInfoViewController+Network.swift
@@ -12,9 +12,8 @@ extension PillInfoViewController {
                 let pillDetailInfo = try await pillInfoManager.getPillDetailInfo(noticeId: noticeId, pillId: pillId)
                 if let pillDetailInfo = pillDetailInfo {
                     self.pillInfoList = pillDetailInfo
-                    setInfoData()
                 }
-                
+                print("getPillDetailInfo에서 찍힌거", pillInfoList)
             }
         }
     }

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeSecond/PillInfoViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeSecond/PillInfoViewController.swift
@@ -14,12 +14,12 @@ final class PillInfoViewController: UIViewController {
     private let pillInfoView = PillInfoView()
     private let timeView = TimeView()
     var noticeId: Int = 0 {
-        didSet {
+        willSet {
             setInfoData()
         }
     }
     var pillId: Int = 0 {
-        didSet {
+        willSet {
             setInfoData()
         }
     }
@@ -31,7 +31,7 @@ final class PillInfoViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         target()
-        getPillDetailInfo(noticeId: 43, pillId: 505) // TODO: - noticeFirst로부터 넘어온 데이터 넣기
+        getPillDetailInfo(noticeId: self.noticeId, pillId: self.pillId)
     }
 }
 

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeSecond/PillInfoViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeSecond/PillInfoViewController.swift
@@ -14,12 +14,12 @@ final class PillInfoViewController: UIViewController {
     private let pillInfoView = PillInfoView()
     private let timeView = TimeView()
     var noticeId: Int = 0 {
-        willSet {
+        didSet {
             setInfoData()
         }
     }
     var pillId: Int = 0 {
-        willSet {
+        didSet {
             setInfoData()
         }
     }
@@ -32,6 +32,7 @@ final class PillInfoViewController: UIViewController {
         super.viewDidLoad()
         target()
         getPillDetailInfo(noticeId: self.noticeId, pillId: self.pillId)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: self.setInfoData)
     }
 }
 
@@ -48,6 +49,9 @@ extension PillInfoViewController: NoticeSecondControl {
     }
 
     func setInfoData() {
+//        getPillDetailInfo(noticeId: self.noticeId, pillId: self.pillId)
+        print("setInfoData에서 찍힌거", pillInfoList)
+        
         let timeCount: Int = pillInfoList?.makeTimeCount() ?? 0
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = FormatType.full.description
@@ -70,9 +74,7 @@ extension PillInfoViewController: NoticeSecondControl {
             pillInfoView.intervalButton.setTitle("특정 간격", for: .normal)
             pillInfoView.intervalLabel.text = "\(interval ?? "")"
         }
-        else {
-            fatalError("존재하지 않는 case")
-        }
+        else { print("존재하지 않는 case") }
 
         pillInfoView.titleLabel.text = pillInfoList?.pillName
         pillInfoView.periodLabel.text = "\(startDate) ~ \(endDate)"


### PR DESCRIPTION
## 🌴 PR 요약
- 현재 수정한 것들 합쳐두고 아래 TODO 이어서 하겠습니더
- TODO
   - 약, 캘린더 수락 및 거절 로직 수정 (= 알랏창에서 취소 눌렀을 때 액션, API 재연결, 셀 업데이트 이슈 해결)
   - 레이아웃 세부 조절 (버튼 터치영역 포함)
 
<!-- PR의 내용을 요약해주세요. -->

🌱 작업한 브랜치

- feature/#297

🌱 작업한 내용

- 약 정보 상세보기 뷰 레이아웃 조정
- NoticeSecond로 데이터 전달
- 버튼 활성화 (화면 전환)

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| -  | - |

## 📮 관련 이슈

- Resolved: #297