### PR TITLE
[#308] 메인 플로우 서버 호출 개선

### DIFF
--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		BD0C707D2862060500CF452F /* ScheduleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0C707C2862060500CF452F /* ScheduleHeaderView.swift */; };
 		BD0C707F2862273C00CF452F /* ScheduleDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0C707E2862273C00CF452F /* ScheduleDataSource.swift */; };
 		BD0C70812862274A00CF452F /* ScheduleViewController+FSCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0C70802862274A00CF452F /* ScheduleViewController+FSCalendar.swift */; };
+		BD117D0428B3987A00A103FA /* DynamicHeightCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD117D0328B3987A00A103FA /* DynamicHeightCollectionView.swift */; };
 		BD149DCB278B31DC009AA416 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD149DCA278B31DC009AA416 /* TabBarItem.swift */; };
 		BD149DCD278B3369009AA416 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD149DCC278B3369009AA416 /* TabBarController.swift */; };
 		BD14F364278EB4B000F316AF /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD14F362278EB4B000F316AF /* ShareViewController.swift */; };
@@ -307,6 +308,7 @@
 		BD0C707C2862060500CF452F /* ScheduleHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleHeaderView.swift; sourceTree = "<group>"; };
 		BD0C707E2862273C00CF452F /* ScheduleDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleDataSource.swift; sourceTree = "<group>"; };
 		BD0C70802862274A00CF452F /* ScheduleViewController+FSCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScheduleViewController+FSCalendar.swift"; sourceTree = "<group>"; };
+		BD117D0328B3987A00A103FA /* DynamicHeightCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicHeightCollectionView.swift; sourceTree = "<group>"; };
 		BD149DCA278B31DC009AA416 /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
 		BD149DCC278B3369009AA416 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		BD14F362278EB4B000F316AF /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
@@ -682,6 +684,7 @@
 				BD4611C228608389007BEE87 /* CalendarTopView.swift */,
 				BD67B63A2860CF4900F1B96A /* ScheduleEmptyView.swift */,
 				BD0C707C2862060500CF452F /* ScheduleHeaderView.swift */,
+				BD117D0328B3987A00A103FA /* DynamicHeightCollectionView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1963,6 +1966,7 @@
 			files = (
 				F67798A8289FF39800AAD2EF /* ShareScheduleCell.swift in Sources */,
 				EC99153F2833BE5A00542115 /* UICollectionView + Extension.swift in Sources */,
+				BD117D0428B3987A00A103FA /* DynamicHeightCollectionView.swift in Sources */,
 				9A3DF0CD2799F4C800D07A8C /* EditFriendDataModel.swift in Sources */,
 				BD58ACF62893CBD600832F01 /* ScheduleViewController+Network.swift in Sources */,
 				BD382F65286B6A19002E91F0 /* BaseModel.swift in Sources */,

--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		BDC83B412798CD2C009C52A1 /* Sticker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC83B402798CD2C009C52A1 /* Sticker.swift */; };
 		BDCDB5CA2861B0A300C419CC /* ScheduleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCDB5C92861B0A300C419CC /* ScheduleCell.swift */; };
 		BDCDB5CD2861B23800C419CC /* ScheduleViewController+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCDB5CC2861B23800C419CC /* ScheduleViewController+Layout.swift */; };
+		BDCEFBF828B20FC600EE0439 /* Notification+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCEFBF728B20FC600EE0439 /* Notification+Extension.swift */; };
 		BDD21A9A278D8705007D10F6 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD21A98278D8705007D10F6 /* MainViewController.swift */; };
 		BDDAA581278997E1000C0AF8 /* Color.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA580278997E1000C0AF8 /* Color.xcassets */; };
 		BDDAA58327899C25000C0AF8 /* Image.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BDDAA58227899C25000C0AF8 /* Image.xcassets */; };
@@ -384,6 +385,7 @@
 		BDC83B402798CD2C009C52A1 /* Sticker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sticker.swift; sourceTree = "<group>"; };
 		BDCDB5C92861B0A300C419CC /* ScheduleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleCell.swift; sourceTree = "<group>"; };
 		BDCDB5CC2861B23800C419CC /* ScheduleViewController+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScheduleViewController+Layout.swift"; sourceTree = "<group>"; };
+		BDCEFBF728B20FC600EE0439 /* Notification+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Extension.swift"; sourceTree = "<group>"; };
 		BDD21A98278D8705007D10F6 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		BDDAA580278997E1000C0AF8 /* Color.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Color.xcassets; sourceTree = "<group>"; };
 		BDDAA58227899C25000C0AF8 /* Image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Image.xcassets; sourceTree = "<group>"; };
@@ -837,6 +839,7 @@
 				ECCF5E6028A03F1A00BC6862 /* UITextField+Extension.swift */,
 				ECCF5E6428A50CD400BC6862 /* UIImage+Extension.swift */,
 				BDAD2D3C28A428EE004ED9A2 /* UIStackView+Extension.swift */,
+				BDCEFBF728B20FC600EE0439 /* Notification+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -2038,6 +2041,7 @@
 				EC91946628224C1A0047893F /* AddPillInfoView.swift in Sources */,
 				ECCF5E7428A62BD900BC6862 /* EditPillPeriodView.swift in Sources */,
 				EC4BF2ED27C0BA9000B28F90 /* SobokButton.swift in Sources */,
+				BDCEFBF828B20FC600EE0439 /* Notification+Extension.swift in Sources */,
 				BD7120E92796A61A0068B981 /* Schedule.swift in Sources */,
 				BDDF7723289A95340096196B /* StickerManager.swift in Sources */,
 				9A3DF0C62798CE4300D07A8C /* EditFriendNameViewController.swift in Sources */,

--- a/SobokSobok/SobokSobok/Common/Extension/Notification+Extension.swift
+++ b/SobokSobok/SobokSobok/Common/Extension/Notification+Extension.swift
@@ -1,0 +1,38 @@
+//
+//  Notification+Extension.swift
+//  SobokSobok
+//
+//  Created by taekki on 2022/08/21.
+//
+
+import Foundation
+
+extension Notification.Name {
+    
+    /*
+     - 스티커 전체보기
+     - 스티커 바텀 시트
+     */
+    static let showAllSticker = NSNotification.Name("showAllSticker")
+    
+    /*
+     - 스티커 전송
+     */
+    static let sendSticker = NSNotification.Name("sendSticker")
+}
+
+extension Notification.Name {
+    
+    func post(object: Any? = nil, userInfo: [AnyHashable : Any]? = nil) {
+        NotificationCenter.default.post(name: self, object: object, userInfo: userInfo)
+    }
+
+    @discardableResult
+    func addObserver(object: Any? = nil, queue: OperationQueue? = nil, using: @escaping (Notification) -> Void) -> NSObjectProtocol {
+        return NotificationCenter.default.addObserver(forName: self, object: object, queue: queue, using: using)
+    }
+    
+    func removeObserver(observer: Any, object: Any? = nil) {
+        return NotificationCenter.default.removeObserver(observer, name: self, object: object)
+    }
+}

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Cells/ScheduleCell.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Cells/ScheduleCell.swift
@@ -142,11 +142,6 @@ extension ScheduleCell {
     
     @objc func stickerButtonTapped(_ sender: UIButton) {
         guard let scheduleId = pill?.scheduleId else { return }
-        
-        NotificationCenter.default.post(
-            name: Notification.Name("sticker"),
-            object: nil,
-            userInfo: ["scheduleId" : scheduleId]
-        )
+        Notification.Name.showAllSticker.post(object: nil, userInfo: ["scheduleId" : scheduleId])
     }
 }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+FSCalendar.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+FSCalendar.swift
@@ -10,25 +10,6 @@
 import FSCalendar
 import Foundation
 
-extension ScheduleViewController {
-    func setCalendar() {
-        calendarView.locale = Locale(identifier: "ko_KR")
-        calendarView.headerHeight = 0
-        calendarView.firstWeekday = 2
-        calendarView.setScope(.week, animated: false)
-        calendarView.select(Date())
-    }
-    
-    func setCalendarStyle() {
-        calendarView.appearance.weekdayFont = TypoStyle.body7.font
-        calendarView.appearance.weekdayTextColor = Color.gray600
-        calendarView.appearance.titleFont = UIFont.font(.pretendardRegular, ofSize: 16)
-        calendarView.appearance.titleDefaultColor = Color.black
-        calendarView.appearance.titleTodayColor = Color.black
-        calendarView.appearance.todayColor = .clear
-        calendarView.placeholderType = .none
-    }
-}
 
 // MARK: - FSCalendar Delegate
 

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
@@ -31,18 +31,20 @@ extension ScheduleViewController {
         }
     }
     
-    func checkPillSchedule(scheduleId: Int) {
+    func checkPillSchedule(scheduleId: Int, completion: @escaping (() ->())) {
         Task {
             do {
                 let _ = try await scheduleManager.checkPillSchedule(for: scheduleId)
+                completion()
             }
         }
     }
     
-    func uncheckPillSchedule(scheduleId: Int) {
+    func uncheckPillSchedule(scheduleId: Int, completion: @escaping (() -> ())) {
         Task {
             do {
                 let _ = try await scheduleManager.uncheckPillSchedule(for: scheduleId)
+                completion()
             }
         }
     }
@@ -82,18 +84,20 @@ extension ScheduleViewController {
         }
     }
     
-    func postSticker(for scheduleId: Int, withSticker stickerId: Int) {
+    func postSticker(for scheduleId: Int, withSticker stickerId: Int, completion: @escaping (() -> ())) {
         Task {
             do {
                 let _ = try await stickerManageer.postStickers(for: scheduleId, withSticker: stickerId)
+                completion()
             }
         }
     }
     
-    func changeSticker(for likeScheduleId: Int, withSticker stickerId: Int) {
+    func changeSticker(for likeScheduleId: Int, withSticker stickerId: Int, completion: @escaping (() -> ())) {
         Task {
             do {
                 let _ = try await stickerManageer.changeSticker(for: likeScheduleId, withSticker: stickerId)
+                completion()
             }
         }
     }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
@@ -8,19 +8,6 @@
 import UIKit
 import FSCalendar
 
-class DynamicHeightCollectionView: UICollectionView {
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        if !__CGSizeEqualToSize(bounds.size, self.intrinsicContentSize) {
-            self.invalidateIntrinsicContentSize()
-        }
-    }
-    
-    override var intrinsicContentSize: CGSize {
-        return contentSize
-    }
-}
-
 final class ScheduleViewController: BaseViewController {
     
     // MARK: - Properties
@@ -29,18 +16,17 @@ final class ScheduleViewController: BaseViewController {
     let stickerManageer: StickerServiceable = StickerManager(apiService: APIManager(), environment: .development)
     
     let gregorian = Calendar(identifier: .gregorian)
-    
-    var friendName: String? {
-        didSet {
-            updateUI()
-        }
-    }
-    
+    var friendName: String? { didSet { updateUI() } }
+
     var schedules: [Schedule] = [] {
         didSet {
             parseSchedules()
         }
     }
+    
+    var doingDates: [String] = []
+    var doneDates: [String] = []
+    
     var pillLists: [PillList] = [] {
         didSet {
             dataSource.update(with: pillLists)
@@ -50,18 +36,14 @@ final class ScheduleViewController: BaseViewController {
 
     var currentDate: Date = Date() {
         didSet {
-            callRequestSchedules()
-            updateUI()
-            collectionView.reloadData()
+            fetchSchedules(for: scheduleType)
+            fetchPillLists(for: scheduleType)
         }
     }
-    var selectedDate = Date().toString(of: .day)
-    var doingDates: [String] = []
-    var doneDates: [String] = []
-    
-    var calendarHeight: CGFloat = 308.0
+
+    var calendarHeight: CGFloat = 308.0.adjustedHeight
     var collectionViewHeight: CGFloat = 409.0.adjustedHeight
-    private var collectionViewBottomInset: CGFloat = 32.0.adjustedHeight
+    var collectionViewBottomInset: CGFloat = 32.0.adjustedHeight
     
     private var scheduleType: ScheduleType
     private lazy var dataSource = ScheduleDataSource(
@@ -91,39 +73,24 @@ final class ScheduleViewController: BaseViewController {
     
     // MARK: - UI Components
     
-    lazy var scrollView = UIScrollView().then {
-        $0.showsVerticalScrollIndicator = false
-        $0.backgroundColor = Color.gray150
-    }
-    
-    private lazy var stackView = UIStackView().then {
-        $0.backgroundColor = .systemBackground
-        $0.axis = .vertical
-        $0.distribution = .fill
-        $0.alignment = .center
-    }
-    
-    private lazy var friendNameView = FriendNameView()
-    private let  calendarTopView = CalendarTopView()
-    lazy var  calendarView = FSCalendar()
-    
+    lazy var scrollView = UIScrollView()
+    lazy var stackView = UIStackView()
+    lazy var friendNameView = FriendNameView()
+    lazy var calendarTopView = CalendarTopView()
+    lazy var calendarView = FSCalendar()
     lazy var collectionView = DynamicHeightCollectionView(
         frame: .zero,
         collectionViewLayout: UICollectionViewLayout()
     )
-    
-    lazy var emptyView = ScheduleEmptyView(for: scheduleType)
-    
+
     
     // MARK: - Life Cycles
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setDelegation()
-        callRequestSchedules()
-        addObservers()
-        editFriendName()
+        fetchSchedules(for: scheduleType)
+        fetchPillLists(for: scheduleType)
     }
     
     override func viewDidLayoutSubviews() {
@@ -133,23 +100,22 @@ final class ScheduleViewController: BaseViewController {
     }
 
     
-    // MARK: - Override Functions
+    // MARK: - Overriding Functions
     
     override func style() {
-        updateUI()
-        setCalendar()
-        setCalendarStyle()
-        setCollectionView()
-        registerCells()
+        configureInitialSetup()
     }
     
     override func hierarchy() {
         view.addSubviews(scrollView)
         scrollView.addSubview(stackView)
-        stackView.addArrangedSubviews(friendNameView, calendarTopView, calendarView, collectionView)
+        stackView.addArrangedSubviews(
+            friendNameView, calendarTopView, calendarView, collectionView
+        )
     }
     
     override func layout() {
+        
         scrollView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
@@ -184,117 +150,57 @@ final class ScheduleViewController: BaseViewController {
     }
 }
 
-// MARK: - Observers
+
+// =============================================
+// MARK: - Initial Setup
+// =============================================
 
 extension ScheduleViewController {
     
-    private func addObservers() {
-        showAllStickerObserver()
-        sendStickerObserver()
-    }
-    
-    private func removeObservers() {
-        Notification.Name.showAllSticker.removeObserver(observer: self)
-        Notification.Name.sendSticker.removeObserver(observer: self)
-    }
-}
-
-extension ScheduleViewController: MainScheduleCellDelegate {
-    func checkButtonTapped(_ cell: MainScheduleCell) {
-        guard let scheduleId = cell.pill?.scheduleId else { return }
+    private func configureInitialSetup() {
         
-        if cell.isChecked {
-            showAlert(
-                title: "복약하지 않은 약인가요?",
-                message: "복약을 취소하면 소중한 사람들의 응원도 같이 삭제되어요",
-                completionTitle: "복약 취소",
-                cancelTitle: "취소"
-            ) { [weak self] _ in
-                cell.isChecked.toggle()
-                self?.uncheckPillSchedule(scheduleId: scheduleId)
-            }
-        }
-        else {
-            cell.isChecked.toggle()
-            self.checkPillSchedule(scheduleId: scheduleId)
-        }
-    }
-}
-
-// MARK: - Private Function
-
-extension ScheduleViewController {
-    
-    func showAllStickerObserver() {
-        Notification.Name.showAllSticker.addObserver { notification in
-            if let notification = notification.userInfo,
-               let scheduleId = notification["scheduleId"] as? Int {
-                self.getStickers(for: scheduleId) { [weak self] in
-                    self?.showStickerBottomSheet(stickers: self?.stickers)
-                }
-            }
-        }
+        configureAttributes()
+        registerCells()
+        setCalendar()
+        setCalendarStyle()
+        setDelegation()
+        addObservers()
     }
     
-    func sendStickerObserver() {
-        Notification.Name.sendSticker.addObserver { [weak self] notification in
-            guard let self = self else { return }
+    private func configureAttributes() {
+        
+        scrollView.do {
+            $0.showsVerticalScrollIndicator = false
+            $0.backgroundColor = Color.gray150
+        }
+        
+        stackView.do {
+            $0.backgroundColor = .systemBackground
+            $0.axis = .vertical
+            $0.distribution = .fill
+            $0.alignment = .center
+        }
+        
+        friendNameView.do {
+            $0.isHidden = scheduleType == .main
+            $0.friendNameLabel.text = friendName
             
-            if let notification = notification.userInfo,
-               let isLikedState = notification["isLikedState"] as? Bool,
-               let scheduleId = notification["scheduleId"] as? Int,
-               let likeScheduleId = notification["likeScheduleId"] as? Int,
-               let stickerId = notification["stickerId"] as? Int
-            {
-                if isLikedState {
-                    self.changeSticker(for: likeScheduleId, withSticker: stickerId)
-                }
-                else {
-                    self.postSticker(for: scheduleId, withSticker: stickerId)
-                }
-            }
         }
-    }
-
-    private func callRequestSchedules() {
-        switch scheduleType {
-        case .main:
-            getMySchedules(date: currentDate.toString(of: .year))
-            getMyPillLists(date: currentDate.toString(of: .year))
-        case .share:
-            getMemberSchedules(memberId: 187, date: currentDate.toString(of: .year))
-            getMemberPillLists(memberId: 187, date: currentDate.toString(of: .year))
+        
+        calendarTopView.do {
+            $0.dateLabel.text = calendarTopView.scopeState == .week ? currentDate.toString(of: .day) : currentDate.toString(of: .month)
+        }
+        
+        collectionView.do {
+            $0.backgroundColor = Color.gray150
+            $0.collectionViewLayout = self.generateLayout()
         }
     }
     
-    private func updateUI() {
-        friendNameView.isHidden = friendName == nil ? true : false
-        friendNameView.friendNameLabel.text = friendName
-        calendarTopView.dateLabel.text = calendarTopView.scopeState == .week ? currentDate.toString(of: .day) : currentDate.toString(of: .month)
-    }
+    // MARK: - CollectionView
     
-    private func setDelegation() {
-        scrollView.delegate = self
-        calendarView.delegate = self
-        calendarView.dataSource = self
-        calendarTopView.delegate = self
-        collectionView.dataSource = dataSource
-    }
-    
-    // TODO: - 높이 문제 해결 필요
-    
-    func setCollectionViewHeight() {
-        var newCollectionViewHeight = pillLists.isEmpty ? 409.0 : collectionView.contentSize.height
-        newCollectionViewHeight = newCollectionViewHeight < 409.0 ? 409.0 : newCollectionViewHeight
-        if newCollectionViewHeight > 0 {
-            collectionViewHeight = newCollectionViewHeight
-            collectionView.snp.updateConstraints {
-                $0.height.equalTo(collectionViewHeight + collectionViewBottomInset)
-            }
-        }
-    }
-    
-    func registerCells() {
+    private func registerCells() {
+        
         calendarView.register(
             CalendarDayCell.self,
             forCellReuseIdentifier: CalendarDayCell.reuseIdentifier
@@ -317,11 +223,150 @@ extension ScheduleViewController {
         )
     }
     
-    func setCollectionView() {
-        collectionView.backgroundColor = Color.gray150
-        collectionView.collectionViewLayout = generateLayout()
+    // MARK: - Calendar
+    
+    func setCalendar() {
+        calendarView.locale = Locale(identifier: "ko_KR")
+        calendarView.headerHeight = 0
+        calendarView.firstWeekday = 2
+        calendarView.setScope(.week, animated: false)
+        calendarView.select(Date())
     }
     
+    func setCalendarStyle() {
+        calendarView.appearance.weekdayFont = TypoStyle.body7.font
+        calendarView.appearance.weekdayTextColor = Color.gray600
+        calendarView.appearance.titleFont = UIFont.font(.pretendardRegular, ofSize: 16)
+        calendarView.appearance.titleDefaultColor = Color.black
+        calendarView.appearance.titleTodayColor = Color.black
+        calendarView.appearance.todayColor = .clear
+        calendarView.placeholderType = .none
+    }
+    
+    // MARK: - Delegation
+    
+    private func setDelegation() {
+        scrollView.delegate = self
+        calendarView.delegate = self
+        calendarView.dataSource = self
+        calendarTopView.delegate = self
+        collectionView.dataSource = dataSource
+    }
+}
+
+
+// =============================================
+// MARK: - UI
+// =============================================
+
+extension ScheduleViewController {
+    
+    private func updateUI() {
+        friendNameView.isHidden = friendName == nil ? true : false
+        friendNameView.friendNameLabel.text = friendName
+        calendarTopView.dateLabel.text = calendarTopView.scopeState == .week ? currentDate.toString(of: .day) : currentDate.toString(of: .month)
+    }
+    
+    // TODO: - 높이 문제 해결 필요
+    
+    func setCollectionViewHeight() {
+        var newCollectionViewHeight = pillLists.isEmpty ? 409.0 : collectionView.contentSize.height
+        newCollectionViewHeight = newCollectionViewHeight < 409.0 ? 409.0 : newCollectionViewHeight
+        if newCollectionViewHeight > 0 {
+            collectionViewHeight = newCollectionViewHeight
+            collectionView.snp.updateConstraints {
+                $0.height.equalTo(collectionViewHeight + collectionViewBottomInset)
+            }
+        }
+    }
+}
+
+
+// =============================================
+// MARK: - Observing
+// =============================================
+
+extension ScheduleViewController {
+    
+    private func addObservers() {
+        showAllStickerObserver()
+        sendStickerObserver()
+    }
+    
+    private func removeObservers() {
+        Notification.Name.showAllSticker.removeObserver(observer: self)
+        Notification.Name.sendSticker.removeObserver(observer: self)
+    }
+    
+    func showAllStickerObserver() {
+        Notification.Name.showAllSticker.addObserver { notification in
+            if let notification = notification.userInfo,
+               let scheduleId = notification["scheduleId"] as? Int {
+                self.getStickers(for: scheduleId) { [weak self] in
+                    self?.showStickerBottomSheet(stickers: self?.stickers)
+                }
+            }
+        }
+    }
+    
+    func sendStickerObserver() {
+        if scheduleType == .share {
+            Notification.Name.sendSticker.addObserver { [weak self] notification in
+                guard let self = self else { return }
+                
+                if let notification = notification.userInfo,
+                   let isLikedState = notification["isLikedState"] as? Bool,
+                   let scheduleId = notification["scheduleId"] as? Int,
+                   let likeScheduleId = notification["likeScheduleId"] as? Int,
+                   let stickerId = notification["stickerId"] as? Int
+                {
+                    if isLikedState {
+                        print("✂️ 호출")
+                        self.changeSticker(for: likeScheduleId, withSticker: stickerId) { [weak self] in
+                            guard let self = self else { return }
+                            self.getMemberPillLists(memberId: 187, date: self.currentDate.toString(of: .year))
+                        }
+                    }
+                    else {
+                        print("🛳 호출")
+                        self.postSticker(for: scheduleId, withSticker: stickerId) { [weak self] in
+                            guard let self = self else { return }
+                            self.getMemberPillLists(memberId: 187, date: self.currentDate.toString(of: .year))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+// =============================================
+// MARK: - Network Call
+// =============================================
+
+extension ScheduleViewController {
+
+    private func fetchSchedules(for type: ScheduleType) {
+        switch type {
+        case .main:
+            getMySchedules(date: currentDate.toString(of: .year))
+            
+        case .share:
+            getMemberSchedules(memberId: 187, date: currentDate.toString(of: .year))
+        }
+    }
+    
+    private func fetchPillLists(for type: ScheduleType) {
+        switch type {
+        case .main:
+            getMyPillLists(date: currentDate.toString(of: .year))
+            
+        case .share:
+            getMemberPillLists(memberId: 187, date: currentDate.toString(of: .year))
+        }
+    }
+
     func parseSchedules() {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = FormatType.full.description
@@ -337,6 +382,22 @@ extension ScheduleViewController {
         self.doingDates = doingItems
         
         calendarView.reloadData()
+    }
+}
+
+
+// =============================================
+// MARK: - Transition
+// =============================================
+
+extension ScheduleViewController {
+    
+    func editFriendName() {
+        friendNameView.completion = {
+            let editFriendNameViewController = EditFriendNameViewController.instanceFromNib()
+            editFriendNameViewController.modalPresentationStyle = .fullScreen
+            self.present(editFriendNameViewController, animated: true)
+        }
     }
     
     func showStickerBottomSheet(stickers: [Stickers]?) {
@@ -360,17 +421,27 @@ extension ScheduleViewController {
     }
 }
 
-extension ScheduleViewController {
-    func editFriendName() {
-        friendNameView.completion = {
-            let editFriendNameViewController = EditFriendNameViewController.instanceFromNib()
-            editFriendNameViewController.modalPresentationStyle = .fullScreen
-            self.present(editFriendNameViewController, animated: true)
-        }
+
+// =============================================
+// MARK: - Delegate
+// =============================================
+
+
+// MARK: - UIScrollViewDelegate
+
+extension ScheduleViewController: UIScrollViewDelegate {
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        scrollView.bounces = scrollView.contentOffset.y > 0
+        scrollView.backgroundColor = scrollView.contentOffset.y > 0 ? Color.gray150 : Color.white
     }
 }
 
+
+// MARK: - CalendarTopViewDelegate
+
 extension ScheduleViewController: CalendarTopViewDelegate {
+    
     func calendarTopView(scope: CalendarScopeState) {
         calendarView.setScope(scope == .week ? .week : .month, animated: true)
         calendarTopView.scopeButton.setTitle(scope == .week ? "주" : "월", for: .normal)
@@ -379,9 +450,34 @@ extension ScheduleViewController: CalendarTopViewDelegate {
     }
 }
 
-extension ScheduleViewController: UIScrollViewDelegate {
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollView.bounces = scrollView.contentOffset.y > 0
-        scrollView.backgroundColor = scrollView.contentOffset.y > 0 ? Color.gray150 : Color.white
+
+// MARK: - MainScheduleCellDelegate
+
+extension ScheduleViewController: MainScheduleCellDelegate {
+    
+    func checkButtonTapped(_ cell: MainScheduleCell) {
+        guard let scheduleId = cell.pill?.scheduleId else { return }
+        
+        if cell.isChecked {
+            showAlert(
+                title: "복약하지 않은 약인가요?",
+                message: "복약을 취소하면 소중한 사람들의 응원도 같이 삭제되어요",
+                completionTitle: "복약 취소",
+                cancelTitle: "취소"
+            ) { [weak self] _ in
+                cell.isChecked.toggle()
+                self?.uncheckPillSchedule(scheduleId: scheduleId) {
+                    self?.fetchSchedules(for: .main)
+                    self?.calendarView.reloadData()
+                }
+            }
+        }
+        else {
+            cell.isChecked.toggle()
+            self.checkPillSchedule(scheduleId: scheduleId) {
+                self.fetchSchedules(for: .main)
+                self.calendarView.reloadData()
+            }
+        }
     }
 }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Views/DynamicHeightCollectionView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Views/DynamicHeightCollectionView.swift
@@ -1,0 +1,21 @@
+//
+//  DynamicHeightCollectionView.swift
+//  SobokSobok
+//
+//  Created by taekki on 2022/08/22.
+//
+
+import UIKit
+
+class DynamicHeightCollectionView: UICollectionView {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        if !__CGSizeEqualToSize(bounds.size, self.intrinsicContentSize) {
+            self.invalidateIntrinsicContentSize()
+        }
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        return contentSize
+    }
+}

--- a/SobokSobok/SobokSobok/Presentation/Share/SendStickerPopUpViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Share/SendStickerPopUpViewController.swift
@@ -54,10 +54,6 @@ final class SendStickerPopUpViewController: UIViewController {
             "stickerId": stickerId
         ]
         
-        NotificationCenter.default.post(
-            name: Notification.Name("PostSticker"),
-            object: self,
-            userInfo: userInfo
-        )
+        Notification.Name.sendSticker.post(object: nil, userInfo: userInfo)
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->

### 메인 플로우 서버 호출 문제를 개선했습니다. 
기존에 복약 체크/해제, 스티커 전송/수정 시에 데이터가 바로 반영되지 않는 문제를 개선했고, 불필요한 서버 호출을 일부 줄였습니다.

🌱 작업한 브랜치

- feature/#308

🌱 작업한 내용

- 코드 일부 정리 및 수정
- 복약 체크/해제 시 캘린더 실시간 반영 문제 해결
- 스티커 전송/수정 시 스티커 실시간 반영 문제 해결

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | - |

## 📮 관련 이슈

- Resolved: #308
