### PR TITLE
[#312] 공유 탭 수정

### DIFF
--- a/SobokSobok/SobokSobok/Common/Extension/Notification+Extension.swift
+++ b/SobokSobok/SobokSobok/Common/Extension/Notification+Extension.swift
@@ -19,6 +19,11 @@ extension Notification.Name {
      - 스티커 전송
      */
     static let sendSticker = NSNotification.Name("sendSticker")
+    
+    /*
+     - 멤버 정보 탭
+     */
+    static let tapMember = NSNotification.Name("tapMember")
 }
 
 extension Notification.Name {

--- a/SobokSobok/SobokSobok/Presentation/Common/TabBarController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Common/TabBarController.swift
@@ -15,6 +15,7 @@ final class TabBarController: UITabBarController {
     let tabbarManager: ScheduleServiceable = ScheduleManager(apiService: APIManager(), environment: .development)
     
     private var tabs: [UIViewController] = []
+    var members: [Member] = []
     
     // MARK: - View Life Cycle
     
@@ -126,6 +127,7 @@ extension TabBarController {
                 let members = try await tabbarManager.getGroupInformation()
                 if let members = members,
                    !members.isEmpty {
+                    self.members = members
                     UserDefaults.standard.member = members
                 }
             }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Views/FriendNameView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Views/FriendNameView.swift
@@ -30,6 +30,7 @@ final class FriendNameView: BaseView {
             $0.top.equalToSuperview().inset(20.adjustedHeight)
             $0.bottom.equalToSuperview()
             $0.leading.equalToSuperview().offset(20)
+            $0.height.equalTo(35.adjustedHeight)
         }
         
         friendNameEditButton.snp.makeConstraints {

--- a/SobokSobok/SobokSobok/Presentation/Share/ShareViewController+Network.swift
+++ b/SobokSobok/SobokSobok/Presentation/Share/ShareViewController+Network.swift
@@ -13,8 +13,6 @@ extension ShareViewController {
                 if let members = members,
                    !members.isEmpty {
                     self.members = members
-                    shareTopView.friends = members
-                    scheduleViewController.friendName = members.first?.memberName
                 }
             }
         }

--- a/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.swift
@@ -18,9 +18,20 @@ final class ShareViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        addFriend()
 
+        addFriend()
+    }
+  
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)      
+
+        tabBarController?.tabBar.isHidden = false
+        getGroupInformation()
+    }
+    
+    override func layout() {
+        super.layout()
+       
         view.addSubviews(shareTopView, containerView)
         embed(scheduleViewController, inView: containerView)
         
@@ -33,13 +44,6 @@ final class ShareViewController: BaseViewController {
             $0.top.equalTo(shareTopView.snp.bottom)
             $0.leading.bottom.trailing.equalToSuperview()
         }
-    }
-  
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)      
-
-        tabBarController?.tabBar.isHidden = false
-        getGroupInformation()
     }
 }
 

--- a/SobokSobok/SobokSobok/Presentation/Share/Views/ShareTopView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Share/Views/ShareTopView.swift
@@ -11,7 +11,7 @@ final class ShareTopView: BaseView {
     
     var completion: (() -> ())?
     
-    var friends: [Member] = [] {
+    var members: [Member] = [] {
         didSet {
             updateUI()
             updateButton()
@@ -36,14 +36,15 @@ final class ShareTopView: BaseView {
         $0.setImage(Image.icPlus48, for: .normal)
         $0.tintColor = Color.white
         $0.addTarget(self, action: #selector(addFriendButtonTapped), for: .touchUpInside)
-        $0.isHidden = friends.isEmpty
+        $0.isHidden = members.isEmpty
     }
-    
+
     override func setupView() {
         super.setupView()
         
         self.backgroundColor = Color.mint
         self.configureHStackView()
+        self.members = UserDefaults.standard.member
     }
     
     override func setupConstraints() {
@@ -53,6 +54,7 @@ final class ShareTopView: BaseView {
         friendHStackView.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(20.adjustedWidth)
             $0.bottom.equalToSuperview().inset(14.adjustedHeight)
+            $0.height.equalTo(24.adjustedHeight)
         }
         
         addFriendButton.snp.makeConstraints {
@@ -77,16 +79,17 @@ extension ShareTopView {
     }
     
     private func updateUI() {
-        for index in friends.indices {
+        for index in members.indices {
             let button = friendHStackView.arrangedSubviews[index] as! UIButton
             button.isHidden = false
-            button.setTitle(friends[index].memberName, for: .normal)
+            let friendName = members[index].memberName.prefix(2)
+            button.setTitle("\(friendName)", for: .normal)
         }
-        addFriendButton.isHidden = friends.isEmpty
+        addFriendButton.isHidden = members.isEmpty
     }
     
     private func updateButton() {
-        for index in friends.indices {
+        for index in members.indices {
             let button = friendHStackView.arrangedSubviews[index] as! UIButton
             
             if index == currentIndex {
@@ -101,6 +104,8 @@ extension ShareTopView {
     
     @objc func friendNameButtonTapped(_ sender: UIButton) {
         currentIndex = sender.tag
+        
+        Notification.Name.tapMember.post(object: nil, userInfo: ["tapIndex": currentIndex])
     }
     
     @objc func addFriendButtonTapped() {


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->
공유 탭 디테일을 수정 했습니다. (자세한 내용은 아래 목록을 참고해주세요.)

🌱 작업한 브랜치

- feature/#312

🌱 작업한 내용

- 친구 선택에 따른 데이터 로드 대응
- 멤버 스택 뷰와 친구 추가 버튼 Align 수정
- 그룹 정보 불러오는 부분 수정
- 친구 이름 레이블과 이름 편집 버튼 Align 수정

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | - |

## 📮 관련 이슈

- Resolved: #312 
