### PR TITLE
[#324] 코드 정리 및 레이아웃 세부사항 조절

### DIFF
--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/NoticeAlertController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/NoticeAlertController.swift
@@ -12,9 +12,7 @@ extension NoticeViewController {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let acceptAction = UIAlertAction(title: "확인", style: .default) { _ in
             self.modalPresentationStyle = .fullScreen
-            self.dismiss(animated: false) {
-                completion()
-            }
+            self.dismiss(animated: false)
         }
         let refuseAction = UIAlertAction(title: "취소", style: .default)
         [refuseAction, acceptAction].forEach { alert.addAction($0) }
@@ -24,9 +22,7 @@ extension NoticeViewController {
     func makeRefuseAlert(title: String, message: String, completion: @escaping () -> Void) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let acceptAction = UIAlertAction(title: "확인", style: .cancel) { _ in
-            self.dismiss(animated: false) {
-                completion()
-            }
+            self.dismiss(animated: false)
         }
         alert.addAction(acceptAction)
         self.present(alert, animated: true)

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeSecond/PillInfoViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeSecond/PillInfoViewController.swift
@@ -87,13 +87,22 @@ extension PillInfoViewController: NoticeSecondControl {
     private func setTimeViews(timeCount: Int, timeData: [String]) {
         if timeCount == 0 {
             [pillInfoView.timeFirstLine, pillInfoView.timeSecondLine].forEach { $0.isHidden = true }
+            pillInfoView.periodStack.snp.makeConstraints { make in
+                make.top.equalTo(pillInfoView.timeTitleLabel.snp.bottom).offset(49)
+            }
         } else if timeCount <= 3 {
             for index in 0..<timeCount {
                 pillInfoView.timeFirstLine.addArrangedSubview(TimeView(time: timeData[index]))
             }
+            pillInfoView.periodStack.snp.makeConstraints { make in
+                make.top.equalTo(pillInfoView.timeFirstLine.snp.bottom).offset(49)
+            }
         } else if timeCount > 3 {
             for index in 0..<3 { pillInfoView.timeFirstLine.addArrangedSubview(TimeView(time: timeData[index])) }
             for index in 3..<timeCount { pillInfoView.timeSecondLine.addArrangedSubviews(TimeView(time: timeData[index])) }
+            pillInfoView.periodStack.snp.makeConstraints { make in
+                make.top.equalTo(pillInfoView.timeTitleLabel.snp.bottom).offset(143)
+            }
         } else {
             fatalError("Wrong Data: Exceeded maximum number of pills.")
         }

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeSecond/PillInfoViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeSecond/PillInfoViewController.swift
@@ -32,9 +32,8 @@ final class PillInfoViewController: UIViewController {
     }
     override func viewDidLoad() {
         super.viewDidLoad()
+        network()
         target()
-        getPillDetailInfo(noticeId: self.noticeId, pillId: self.pillId)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: self.setInfoData)
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -45,6 +44,15 @@ final class PillInfoViewController: UIViewController {
 
 // MARK: - Extensions
 extension PillInfoViewController: NoticeSecondControl {
+    func network() {
+        SBIndicator.shared.show()
+        getPillDetailInfo(noticeId: self.noticeId, pillId: self.pillId)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            self?.setInfoData()
+            SBIndicator.shared.hide()
+        }
+    }
+    
     func target() {
         pillInfoView.navigationView.navigationButton.addTarget(self, action: #selector(addDismiss), for: .touchUpInside)
     }

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeSecond/Views/PillInfoView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeSecond/Views/PillInfoView.swift
@@ -41,7 +41,7 @@ final class PillInfoView: BaseView {
         $0.axis = .horizontal
         $0.spacing = 12
     }
-    private lazy var timeTitleLabel = UILabel().then {
+    let timeTitleLabel = UILabel().then {
         $0.font = UIFont.font(.pretendardSemibold, ofSize: 16)
         $0.text = "약 먹는 시간"
         $0.textColor = Color.black
@@ -65,7 +65,7 @@ final class PillInfoView: BaseView {
         $0.font = UIFont.font(.pretendardMedium, ofSize: 18)
         $0.textColor = Color.darkMint
     }
-    private lazy var periodStack = UIStackView().then {
+    let periodStack = UIStackView().then {
         $0.alignment = .fill
         $0.axis = .vertical
         $0.spacing = 7
@@ -121,7 +121,7 @@ final class PillInfoView: BaseView {
             make.height.equalTo(38)
         }
         periodStack.snp.makeConstraints { make in
-            make.top.equalTo(timeTitleLabel.snp.bottom).offset(143)
+//            make.top.equalTo(timeTitleLabel.snp.bottom).offset(143)
             make.leading.equalTo(20)
         }
     }

--- a/SobokSobok/SobokSobok/Presentation/Notice/Protocol/NoticeSecondControl.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/Protocol/NoticeSecondControl.swift
@@ -7,4 +7,6 @@
 
 import Foundation
 
-protocol NoticeSecondControl: TargetProtocol {}
+protocol NoticeSecondControl: TargetProtocol {
+    func network()
+}


### PR DESCRIPTION
## 🌴 PR 요약
- 디자인 QA 반영
- 서버통신 코드 개선
<!-- PR의 내용을 요약해주세요. -->

🌱 작업한 브랜치

- feature/#324

🌱 작업한 내용

- 약 개수가 3개 이하일 때 레이아웃 하단 제약조건 수정
- 통신관련 함수 중복으로 호출하는 코드 제거
- 약 정보 상세보기 뷰 서버통신 시간 동안 로딩 인디케이터 추가

## 📮 관련 이슈

- Resolved: #324
