### PR TITLE
[#354] 디자인 QA 반영

### DIFF
--- a/SobokSobok/SobokSobok/Presentation/Common/Indicator/SBIndicator.swift
+++ b/SobokSobok/SobokSobok/Presentation/Common/Indicator/SBIndicator.swift
@@ -25,7 +25,8 @@ final class SBIndicator: BaseView {
     }
     
     override func setupConstraints() {
-        self.backgroundColor = .black.withAlphaComponent(0.3)
+//        self.backgroundColor = .black.withAlphaComponent(0.3)
+        self.backgroundColor = .white
         
         self.addSubview(self.contentView)
         self.contentView.addSubview(self.loadingView)

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/NoticeViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/NoticeViewController.swift
@@ -117,7 +117,7 @@ extension NoticeViewController: UICollectionViewDataSource {
             else if noticeList?.infoList[indexPath.row].section == "pill" {
                 cell.setupView(section: .pill, status: .waite)
                 cell.nameLabel.text = "\(pillName)"
-                cell.descriptionLabel.text = "\(groupName)님이 보낸 약 알림 일정을 보냈어요"
+                cell.descriptionLabel.text = "\(groupName)님이 약 알림 일정을 보냈어요"
                 
                 if UserDefaults.standard.integer(forKey: "sendedPillCount") == 0 {
                     cell.toolTipView.isHidden = false

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/NoticeViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/NoticeViewController.swift
@@ -53,6 +53,8 @@ extension NoticeViewController: NoticeFistControl {
 extension NoticeViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if noticeList?.infoList.isEmpty == true {
+            let userName = noticeList?.userName ?? ""
+            noticeListView.titleLabel.text = "소중한 " + userName + "님의 알림"
             collectionView.setEmptyView(
                 image: Image.illustOops, message: "아직 도착한 알림이 없어요!"
             )

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/EmptyView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/EmptyView.swift
@@ -29,16 +29,14 @@ extension UICollectionView {
         // MARK: - Render
         [sobokImage, descriptionLabel].forEach { emptyView.addSubview($0) }
 
-        sobokImage.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(178)
-            $0.leading.equalToSuperview()
-            $0.trailing.equalToSuperview()
-            $0.height.equalTo(165.adjustedHeight)
+        sobokImage.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(178)
+            make.centerX.equalToSuperview()
+            make.height.equalTo(165.adjustedHeight)
         }
-        descriptionLabel.snp.makeConstraints {
-            $0.width.equalTo(318.adjustedWidth)
-            $0.top.equalTo(sobokImage.snp.bottom).offset(29)
-            $0.centerX.equalToSuperview()
+        descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(sobokImage.snp.bottom).offset(29)
+            make.centerX.equalToSuperview()
         }
         self.backgroundView = emptyView
     }

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListCollectionViewCell.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListCollectionViewCell.swift
@@ -35,6 +35,7 @@ final class NoticeListCollectionViewCell: UICollectionViewCell, NoticeListPresen
     private lazy var topStackView =  UIStackView().then {
         $0.axis = .horizontal
         $0.distribution = .fill
+        $0.spacing = 10
     }
     private lazy var iconImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFit
@@ -103,7 +104,7 @@ final class NoticeListCollectionViewCell: UICollectionViewCell, NoticeListPresen
         statusType = status
         divideSection()
         
-        topStackView.addArrangedSubviews(iconImageView, nameLabel, detailButton)
+        topStackView.addArrangedSubviews(iconImageView, nameLabel, detailButton, toolTipView)
         topStackView.bringSubviewToFront(toolTipView)
         middleStackView.addArrangedSubviews(descriptionLabel, timeLabel)
         bottomStackView.addArrangedSubviews(refuseButton, acceptButton)
@@ -132,12 +133,17 @@ final class NoticeListCollectionViewCell: UICollectionViewCell, NoticeListPresen
         nameLabel.snp.makeConstraints { make in
             make.width.equalTo(156.adjustedWidth)
             make.top.equalTo(topStackView.snp.top)
-            make.leading.equalTo(topStackView.snp.leading).offset(32)
+            make.leading.equalTo(topStackView.snp.leading).inset(30)
         }
         detailButton.snp.makeConstraints { make in
             make.width.equalTo(72.adjustedWidth)
             make.top.equalTo(topStackView.snp.top)
-            make.leading.equalTo(topStackView.snp.leading).offset(227)
+            make.leading.equalTo(topStackView.snp.leading).inset(217)
+        }
+        toolTipView.snp.makeConstraints { make in
+            make.width.equalTo(247.adjustedWidth)
+            make.height.equalTo(36.adjustedHeight)
+            make.top.equalTo(detailButton.snp.bottom).offset(1)
         }
 
         // MARK: - middle

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListSection.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/Cell/NoticeListSection.swift
@@ -14,7 +14,7 @@ extension NoticeViewController {
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(180.adjustedHeight))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 1)
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = .init(top: 18, leading: 0, bottom: 0, trailing: 0)
+        section.contentInsets = .init(top: 0, leading: 0, bottom: 32, trailing: 0)
         section.interGroupSpacing = 8
         section.orthogonalScrollingBehavior = .none
         

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/NoticeListView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/NoticeListView.swift
@@ -34,7 +34,7 @@ final class NoticeListView: BaseView {
             $0.leading.equalToSuperview().offset(20)
         }
         noticeListCollectionView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(117)
+            $0.top.equalToSuperview().offset(147)
             $0.leading.equalToSuperview().offset(20)
             $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(32)
             $0.trailing.equalToSuperview().inset(20)

--- a/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/NoticeListView.swift
+++ b/SobokSobok/SobokSobok/Presentation/Notice/NoticeFirst/Views/NoticeListView.swift
@@ -36,7 +36,7 @@ final class NoticeListView: BaseView {
         noticeListCollectionView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(147)
             $0.leading.equalToSuperview().offset(20)
-            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(32)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
             $0.trailing.equalToSuperview().inset(20)
         }
     }


### PR DESCRIPTION
## 🌴 PR 요약
- 디자인 QA를 반영했습니다.

- 수락/거절 완료 시 탭 이동해야 바뀌는 것은 아래 확인 못한 부분과 함께 기능 QA 반영 이슈를 따로 만들어서 작업하겠습니다.
  - 처음 약을 전송받으면 툴팁이 떠야합니다. (확인 필요)
  - 5개 약이 이미 추가되어있는 상태에서, 보낸 약을 더 수락하면 팝업으로 5개 이상을 막아야함. (확인 필요)
<!-- PR의 내용을 요약해주세요. -->

🌱 작업한 브랜치

- feature/#354

🌱 작업한 내용

- 알림 엠티뷰일 때 상단에 ‘소중한 00님의 알림' 이라는 멘트 필요
- 아닌님이 보낸 약 알림 일정을 보냈어요 → ‘보낸’삭제
- 스크롤 시 상단 사이즈 짤리는거 수정
- 약 아이콘과 약 이름 사이 간격이 좁아보여요.
- 탭바 위에 마진 영역이 없어야 함. (끝까지 스트롤 했을 때만 해당 마진이 있어요.)
- 약 일정을 거절했을 때 → 수락했어요 라고 나옴.(혹시 반대로 되어있는지 확인 필요)
- 로딩뷰 배경값 수정

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| 알림 리스트, 약 정보 상세보기  | <img src="https://user-images.githubusercontent.com/70689381/189478080-cd46b2c4-9a82-47ad-afd4-d65ff4ed8422.gif" width=250> |

## 📮 관련 이슈

- Resolved: #354
