### PR TITLE
[#367] 홈 화면 이번 달 아닌 달 정보는 캘린더에 표시되지 않는 이슈 수정

### DIFF
--- a/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
+++ b/SobokSobok/SobokSobok.xcodeproj/project.pbxproj
@@ -2418,7 +2418,7 @@
 				CODE_SIGN_ENTITLEMENTS = SobokSobok/SobokSobok.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2209081;
+				CURRENT_PROJECT_VERSION = 2210052;
 				DEVELOPMENT_TEAM = W7P3R7ZL78;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SobokSobok/Support/Info.plist;
@@ -2433,7 +2433,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sobok.corp.SobokSobok;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2451,7 +2451,7 @@
 				CODE_SIGN_ENTITLEMENTS = SobokSobok/SobokSobok.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2209081;
+				CURRENT_PROJECT_VERSION = 2210052;
 				DEVELOPMENT_TEAM = W7P3R7ZL78;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SobokSobok/Support/Info.plist;
@@ -2466,7 +2466,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sobok.corp.SobokSobok;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/Home/Schedule.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/Home/Schedule.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Schedule: Codable {
+struct Schedule: Codable, Equatable {
     let scheduleDate: String
     let scheduleCount: String
     let isCheckCount: String

--- a/SobokSobok/SobokSobok/Network/Foundation/APIEnvironment.swift
+++ b/SobokSobok/SobokSobok/Network/Foundation/APIEnvironment.swift
@@ -26,7 +26,6 @@ extension APIEnvironment {
     }
     
     var token: String {
-//        return "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjQyLCJuYW1lIjoi66mU7J247YOc64G8IiwiaWF0IjoxNjYxNzUxNjQ3LCJleHAiOjE2NjQzNDM2NDcsImlzcyI6InNvYm9rIn0.dj8t-BwbFgiqOlqpJ0PB6yGK9YFRgtgnniLkElyrs5k"
         return UserDefaultsManager.accessToken
     }
 }

--- a/SobokSobok/SobokSobok/Network/Foundation/APIManager.swift
+++ b/SobokSobok/SobokSobok/Network/Foundation/APIManager.swift
@@ -24,13 +24,8 @@ final class APIManager: Requestable {
             throw APIError.serverError
         }
 
-        print("✅✅✅✅✅✅✅✅✅", data)
-        
         let decodedData = try JSONDecoder().decode(BaseModel<T>.self, from: data)
 
-        
-        print("⛔️⛔️⛔️⛔️⛔️⛔️⛔️⛔️⛔️", decodedData)
-        
         if decodedData.success {
             return decodedData.data
         } else {

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController+Network.swift
@@ -5,14 +5,28 @@
 //  Created by taekki on 2022/07/29.
 //
 
+import Foundation
+
 extension ScheduleViewController {
-    func getMySchedules(date: String) {
+    func getMySchedules(date: Date) {
         Task {
             do {
-                let schedules = try await scheduleManager.getMySchedule(for: date)
-                if let schedules = schedules,
-                   !schedules.isEmpty {
-                    self.schedules = schedules
+                let prev = Calendar.current.date(byAdding: .month, value: -1, to: date)!.toString(of: .year)
+                let current = date.toString(of: .year)
+                let next = Calendar.current.date(byAdding: .month, value: 1, to: date)!.toString(of: .year)
+
+                var tmp: [Schedule] = []
+                for date in [prev, current, next] {
+                    let schedules = try await scheduleManager.getMySchedule(for: date)
+                    if let schedules = schedules,
+                       !schedules.isEmpty {
+                        tmp.append(contentsOf: schedules)
+                    }
+                }
+                
+                if tmp != self.schedules {
+                    self.schedules.removeAll()
+                    self.schedules = tmp
                     self.calendarView.reloadData()
                 }
             }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
@@ -397,10 +397,7 @@ extension ScheduleViewController {
             getMyPillLists(date: currentDate.toString(of: .year))
             
         case .share:
-            guard !member.isEmpty else {
-                print("멤버가 없어요!! 📞📞📞📞📞📞📞📞📞📞📞")
-                return
-            }
+            guard !member.isEmpty else { return }
             getMemberPillLists(memberId: member[tapIndex].memberId, date: currentDate.toString(of: .year))
         }
     }

--- a/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Schedule/Controllers/ScheduleViewController.swift
@@ -383,7 +383,7 @@ extension ScheduleViewController {
     private func fetchSchedules(for type: ScheduleType) {
         switch type {
         case .main:
-            getMySchedules(date: currentDate.toString(of: .year))
+            getMySchedules(date: currentDate)
             
         case .share:
             guard !member.isEmpty else { return }


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->

🌱 작업한 브랜치

- feature/#367

🌱 작업한 내용

- 홈 화면 이번 달 아닌 달 정보는 캘린더에 표시되지 않는 이슈 수정
  - API Call 시에 이번달을 기준으로 이전 달과 다음 달의 정보를 한꺼번에 가져오는 방식으로 해결했습니다.

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  |![Simulator Screen Recording - iPhone 13 mini - 2022-10-05 at 20 06 52](https://user-images.githubusercontent.com/61109660/194047864-9d4e9b8d-f21a-4b78-88b5-fa9504f7e36b.gif)|

## 📮 관련 이슈

- Resolved: #367
