### PR TITLE
[#371] 친구 이름 수정 시 바로 반영되게 수정

### DIFF
--- a/SobokSobok/SobokSobok/Data/DTO/APIModel/Share/Member.swift
+++ b/SobokSobok/SobokSobok/Data/DTO/APIModel/Share/Member.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 struct Member: Codable {
-    let groupId: Int
-    let memberId: Int
-    let memberName: String
+    var groupId: Int
+    var memberId: Int
+    var memberName: String
 }

--- a/SobokSobok/SobokSobok/Presentation/Share/EditFriendName/EditFriendNameViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Share/EditFriendName/EditFriendNameViewController.swift
@@ -103,11 +103,24 @@ final class EditFriendNameViewController: UIViewController, EditFriendnameProtoc
     @IBAction func touchUpToConfirm(_ sender: Any) {
 //        EditFriend.shared.groupId = 31 // 화면 연결되면 전달 받아야함
 //        EditFriend.shared.memberName = nameTextField.text ?? ""
-        editFriendNickname(at: groupId ?? 0, for: nameTextField.text ?? "") // TODO: - at 부분에 전달 받은 groupId 넣어주기
+        editFriendNickname(at: groupId ?? 0, for: nameTextField.text ?? "") // TODO: - at 부분에 전달 받은 groupId 넣어주기
         dismiss(animated: true)
     }
     
     @IBAction func touchUpToDIsmiss(_ sender: Any) {
-        dismiss(animated: true)
+        guard let name = nameTextField.text else { return }
+        editFriendNickname(at: groupId ?? 0, for: name)
+
+        var members = UserDefaults.standard.member
+        for index in members.indices {
+            if members[index].groupId == self.groupId {
+                print(name)
+                members[index].memberName = name
+            }
+        }
+
+        dismiss(animated: true) {
+            UserDefaults.standard.member = members
+        }
     }
 }

--- a/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/Share/ShareViewController.swift
@@ -28,9 +28,12 @@ final class ShareViewController: BaseViewController {
     }
   
     override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)      
-
+        super.viewWillAppear(animated)
         tabBarController?.tabBar.isHidden = false
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         getGroupInformation()
     }
     


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->

🌱 작업한 브랜치

- feature/#371

🌱 작업한 내용

- 친구 이름 수정 시 바로 반영되도록 수정했습니다.
  - 서버 반영되는 시간에 약간의 딜레이가 있어, UI를 먼저 변경하고 서버에 요청을 보내는 식으로 해결했습니다.

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | 파일첨부바람 |

## 📮 관련 이슈

- Resolved: #371 
