### PR TITLE
[#373] 재 로그인시 유저 닉네임이 홈 화면에 반영되지 않는 이슈 수정

### DIFF
--- a/SobokSobok/SobokSobok/Network/API/AuthEndPoint.swift
+++ b/SobokSobok/SobokSobok/Network/API/AuthEndPoint.swift
@@ -10,6 +10,7 @@ import Foundation
 enum AuthEndPoint {
     case signUp(socialId: String, username: String, deviceToken: String)
     case signIn(socialId: String, deviceToken: String)
+    case fetchUsername
 }
 
 extension AuthEndPoint: EndPoint {
@@ -17,7 +18,7 @@ extension AuthEndPoint: EndPoint {
         switch self {
         case .signUp:
             return .POST
-        case .signIn:
+        case .signIn, .fetchUsername:
             return .GET
         }
     }
@@ -31,7 +32,7 @@ extension AuthEndPoint: EndPoint {
                 "deviceToken": deviceToken
             ]
             return parameter.encode()
-        case .signIn:
+        case .signIn, .fetchUsername:
             return nil
         }
     }
@@ -43,6 +44,8 @@ extension AuthEndPoint: EndPoint {
             return "\(baseURL)/auth/signup"
         case .signIn(let socialId, let deviceToken):
             return "\(baseURL)/auth/signin?socialId=\(socialId)&deviceToken=\(deviceToken)"
+        case .fetchUsername:
+            return "\(baseURL)/user/info"
         }
     }
     
@@ -66,8 +69,14 @@ extension AuthEndPoint: EndPoint {
                                   httpMethod: method,
                                   requestBody: body,
                                   headers: headers)
+        case .fetchUsername:
+            var headers: [String: String] = [:]
+            headers["Content-Type"] = "application/json"
+            headers["accesstoken"] = environment.token
+            return NetworkRequest(url: getURL(from: environment),
+                                  httpMethod: method,
+                                  requestBody: body,
+                                  headers: headers)
         }
-        
-
     }
 }

--- a/SobokSobok/SobokSobok/Network/Service/AuthManager.swift
+++ b/SobokSobok/SobokSobok/Network/Service/AuthManager.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol AuthServiceable {
     func signUp(socialId: String, username: String, deviceToken: String) async throws -> SignUpResponse?
     func signIn(socialId: String, deviceToken: String) async throws -> SignInResponse?
+    func fetchUsername() async throws -> SignUpResponse?
 }
 
 struct AuthManager: AuthServiceable {
@@ -31,6 +32,13 @@ struct AuthManager: AuthServiceable {
     func signIn(socialId: String, deviceToken: String) async throws -> SignInResponse? {
         let request = AuthEndPoint
             .signIn(socialId: socialId, deviceToken: deviceToken)
+            .createRequest(environment: environment)
+        return try await self.apiService.request(request)
+    }
+    
+    func fetchUsername() async throws -> SignUpResponse? {
+        let request = AuthEndPoint
+            .fetchUsername
             .createRequest(environment: environment)
         return try await self.apiService.request(request)
     }

--- a/SobokSobok/SobokSobok/Presentation/SignIn/SignInViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignIn/SignInViewController.swift
@@ -103,7 +103,6 @@ extension SignInViewController {
                 // 데이터 전달
                 self.userDefaults.set(data.username, forKey: "username")
                 self.userDefaults.set(data.accessToken, forKey: "accessToken")
-                print("\(data.username),\(data.accessToken)")
                 // 화면 이동
                 self.navigationController?.pushViewController(TabBarController.instanceFromNib(), animated: true)
             case .requestErr:

--- a/SobokSobok/SobokSobok/Presentation/SignIn/SocialSignInViewController.swift
+++ b/SobokSobok/SobokSobok/Presentation/SignIn/SocialSignInViewController.swift
@@ -98,6 +98,12 @@ extension SocialSignInViewController {
                 
                 UserDefaultsManager.socialID = socialID
                 UserDefaultsManager.accessToken = accessToken
+                
+                // 유저 닉네임 호출
+                let userResponse = try await authManager.fetchUsername()
+                guard let username = userResponse?.username else { return }
+                UserDefaultsManager.userName = username
+                
                 transitionToMainViewController()
             }
         }


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->
재 로그인시 유저 닉네임이 홈 화면에 반영되지 않는 이슈를 수정했습니다.

🌱 작업한 브랜치

- feature/#373

🌱 작업한 내용

- 유저 닉네임 패치 API 연결
- 존재하는 유저가 재 로그인을 시도할 때 해당 API 호출

## 📸 스크린샷

| 기능 |   스크린샷   |
| :--: | :----------: |
| GIF  | 파일첨부바람 |

## 📮 관련 이슈

- Resolved: #373
